### PR TITLE
feat :: #62 휴대폰 제출함 관리 기능 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ const Notice = lazy(() => import('./pages/Notice'));
 const NoticeDetail = lazy(() => import('./pages/NoticeDetail'));
 const Schedule = lazy(() => import('./pages/Schedule'));
 const Room = lazy(() => import('./pages/Room'));
+const PhoneBox = lazy(() => import('./pages/PhoneBox'));
 const StudentManagement = lazy(() => import('./pages/StudentManagement'));
 const Login = lazy(() => import('./pages/Login'));
 const Terms = lazy(() => import('./pages/Terms'));
@@ -59,6 +60,7 @@ function App() {
           <Route path="notice/:id" element={<NoticeDetail />} />
           <Route path="schedule" element={<Schedule />} />
           <Route path="room" element={<Room />} />
+          <Route path="phone-boxes" element={<PhoneBox />} />
           {/* Teacher 전용 패치노트 페이지 */}
           <Route path="teacher-patchnote" element={<TeacherPatchNote />} />
           <Route

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -109,6 +109,26 @@ function PhoneIcon({ className }: { className?: string }) {
   );
 }
 
+// 휴대폰 제출함 아이콘
+function PhoneBoxIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <rect x="7" y="2" width="10" height="14" rx="2" />
+      <path d="M11 5h2" />
+      <path d="M3 18h18" />
+      <path d="M5 18v3h14v-3" />
+    </svg>
+  );
+}
+
 // 자치위원 아이콘
 function CouncilIcon({ className }: { className?: string }) {
   return (
@@ -165,6 +185,7 @@ export default function Sidebar() {
     { path: '/notice', label: '공지사항', icon: 'notice' },
     { path: '/schedule', label: '일정 관리', icon: 'schedule' },
     { path: '/room', label: '방 관리', icon: 'room' },
+    { path: '/phone-boxes', label: '휴대폰 제출함', icon: 'phonebox' },
     { path: '/teacher-patchnote', label: '패치노트', icon: 'patchnote' },
   ];
 
@@ -193,6 +214,8 @@ export default function Sidebar() {
         return <CalendarIcon className="menu-icon" />;
       case 'room':
         return <RoomIcon className="menu-icon" />;
+      case 'phonebox':
+        return <PhoneBoxIcon className="menu-icon" />;
       case 'council':
         return <CouncilIcon className="menu-icon" />;
       case 'student':

--- a/src/components/phonebox/PhoneBoxCreateModal.tsx
+++ b/src/components/phonebox/PhoneBoxCreateModal.tsx
@@ -1,0 +1,163 @@
+import { useRef, useState } from 'react';
+import '../../styles/RoomModal.css';
+import { PHONE_BOX_GENDER_LABEL } from '../../utils/phone-box';
+import type { CreatePhoneBoxRequest, PhoneBoxGender } from '../../types/api';
+
+const NAME_MAX_LENGTH = 50;
+const GENDER_OPTIONS: PhoneBoxGender[] = ['MALE', 'FEMALE'];
+
+interface PhoneBoxCreateModalProps {
+  defaultGender: PhoneBoxGender;
+  isPending: boolean;
+  requestError: string;
+  onClose: () => void;
+  onSubmit: (data: CreatePhoneBoxRequest) => void;
+}
+
+export default function PhoneBoxCreateModal({
+  defaultGender,
+  isPending,
+  requestError,
+  onClose,
+  onSubmit,
+}: PhoneBoxCreateModalProps) {
+  const backdropMouseDownRef = useRef(false);
+  const [name, setName] = useState('');
+  const [gender, setGender] = useState<PhoneBoxGender>(defaultGender);
+  const [error, setError] = useState('');
+
+  const requestClose = () => {
+    if (isPending) return;
+    onClose();
+  };
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+
+    const trimmedName = name.trim();
+
+    if (!trimmedName) {
+      setError('제출함 이름을 입력해주세요.');
+      return;
+    }
+
+    if (trimmedName.length > NAME_MAX_LENGTH) {
+      setError(`제출함 이름은 ${NAME_MAX_LENGTH}자 이내로 입력해주세요.`);
+      return;
+    }
+
+    setError('');
+    onSubmit({ name: trimmedName, gender });
+  };
+
+  return (
+    <div
+      className="room-modal-backdrop"
+      onMouseDown={(e) => {
+        if (isPending) return;
+        backdropMouseDownRef.current = e.target === e.currentTarget;
+      }}
+      onMouseUp={(e) => {
+        if (isPending) return;
+        if (e.target === e.currentTarget && backdropMouseDownRef.current) {
+          requestClose();
+        }
+        backdropMouseDownRef.current = false;
+      }}
+    >
+      <div className="room-modal">
+        <div className="room-modal-header">
+          <div>
+            <p className="room-modal-eyebrow">Create phone box</p>
+            <h2 className="room-modal-title">제출함 추가</h2>
+          </div>
+          <button
+            className="room-modal-close-button"
+            onClick={requestClose}
+            disabled={isPending}
+            type="button"
+            aria-label="모달 닫기"
+          >
+            ✕
+          </button>
+        </div>
+
+        <form className="room-modal-form" onSubmit={handleSubmit}>
+          <div className="room-form-group">
+            <label className="room-form-label" htmlFor="phonebox-name">
+              제출함 이름 <span className="required">*</span>
+            </label>
+            <input
+              id="phonebox-name"
+              type="text"
+              className="room-form-input"
+              placeholder="예: 1층 남자 제출함"
+              value={name}
+              onChange={(e) => {
+                setName(e.target.value);
+                if (error) setError('');
+              }}
+              maxLength={NAME_MAX_LENGTH}
+              disabled={isPending}
+              autoFocus
+            />
+            <div className="input-footer">
+              {error ? <span className="error-text">{error}</span> : <span />}
+              <span className="char-count">
+                {name.length}/{NAME_MAX_LENGTH}
+              </span>
+            </div>
+          </div>
+
+          <div className="room-form-group">
+            <span className="room-form-label">
+              기숙사 <span className="required">*</span>
+            </span>
+            <div className="phonebox-gender-options" role="radiogroup" aria-label="기숙사 선택">
+              {GENDER_OPTIONS.map((option) => (
+                <button
+                  key={option}
+                  type="button"
+                  role="radio"
+                  aria-checked={gender === option}
+                  className={`phonebox-gender-option ${gender === option ? 'active' : ''}`}
+                  onClick={() => setGender(option)}
+                  disabled={isPending}
+                >
+                  {PHONE_BOX_GENDER_LABEL[option]}
+                </button>
+              ))}
+            </div>
+            <p className="input-helper">
+              선택한 기숙사의 학생만 이 제출함에 배정할 수 있습니다.
+            </p>
+          </div>
+
+          {requestError && (
+            <div className="input-footer">
+              <span className="error-text">{requestError}</span>
+            </div>
+          )}
+
+          <div className="room-modal-actions">
+            <button
+              type="button"
+              className="room-cancel-button"
+              onClick={requestClose}
+              disabled={isPending}
+            >
+              취소
+            </button>
+            <button
+              type="submit"
+              className="room-submit-button"
+              disabled={isPending}
+            >
+              {isPending ? '추가 중...' : '추가'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/phonebox/PhoneBoxEditModal.tsx
+++ b/src/components/phonebox/PhoneBoxEditModal.tsx
@@ -1,0 +1,147 @@
+import { useRef, useState } from 'react';
+import '../../styles/RoomModal.css';
+import { PHONE_BOX_GENDER_LABEL } from '../../utils/phone-box';
+import type { PhoneBoxResponse } from '../../types/api';
+
+const NAME_MAX_LENGTH = 50;
+
+interface PhoneBoxEditModalProps {
+  box: PhoneBoxResponse;
+  isPending: boolean;
+  requestError: string;
+  onClose: () => void;
+  onSubmit: (name: string) => void;
+}
+
+export default function PhoneBoxEditModal({
+  box,
+  isPending,
+  requestError,
+  onClose,
+  onSubmit,
+}: PhoneBoxEditModalProps) {
+  const backdropMouseDownRef = useRef(false);
+  const [name, setName] = useState(box.name);
+  const [error, setError] = useState('');
+
+  const requestClose = () => {
+    if (isPending) return;
+    onClose();
+  };
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+
+    const trimmedName = name.trim();
+
+    if (!trimmedName) {
+      setError('제출함 이름을 입력해주세요.');
+      return;
+    }
+
+    if (trimmedName.length > NAME_MAX_LENGTH) {
+      setError(`제출함 이름은 ${NAME_MAX_LENGTH}자 이내로 입력해주세요.`);
+      return;
+    }
+
+    if (trimmedName === box.name) {
+      setError('기존 이름과 다른 이름을 입력해주세요.');
+      return;
+    }
+
+    setError('');
+    onSubmit(trimmedName);
+  };
+
+  return (
+    <div
+      className="room-modal-backdrop"
+      onMouseDown={(e) => {
+        if (isPending) return;
+        backdropMouseDownRef.current = e.target === e.currentTarget;
+      }}
+      onMouseUp={(e) => {
+        if (isPending) return;
+        if (e.target === e.currentTarget && backdropMouseDownRef.current) {
+          requestClose();
+        }
+        backdropMouseDownRef.current = false;
+      }}
+    >
+      <div className="room-modal">
+        <div className="room-modal-header">
+          <div>
+            <p className="room-modal-eyebrow">Rename phone box</p>
+            <h2 className="room-modal-title">제출함 이름 수정</h2>
+          </div>
+          <button
+            className="room-modal-close-button"
+            onClick={requestClose}
+            disabled={isPending}
+            type="button"
+            aria-label="모달 닫기"
+          >
+            ✕
+          </button>
+        </div>
+
+        <form className="room-modal-form" onSubmit={handleSubmit}>
+          <div className="room-form-group">
+            <label className="room-form-label" htmlFor="phonebox-edit-name">
+              제출함 이름 <span className="required">*</span>
+            </label>
+            <input
+              id="phonebox-edit-name"
+              type="text"
+              className="room-form-input"
+              value={name}
+              onChange={(e) => {
+                setName(e.target.value);
+                if (error) setError('');
+              }}
+              maxLength={NAME_MAX_LENGTH}
+              disabled={isPending}
+              autoFocus
+            />
+            <div className="input-footer">
+              {error ? (
+                <span className="error-text">{error}</span>
+              ) : (
+                <span className="input-example">
+                  {PHONE_BOX_GENDER_LABEL[box.gender]} · 학생 {box.students.length}명
+                </span>
+              )}
+              <span className="char-count">
+                {name.length}/{NAME_MAX_LENGTH}
+              </span>
+            </div>
+          </div>
+
+          {requestError && (
+            <div className="input-footer">
+              <span className="error-text">{requestError}</span>
+            </div>
+          )}
+
+          <div className="room-modal-actions">
+            <button
+              type="button"
+              className="room-cancel-button"
+              onClick={requestClose}
+              disabled={isPending}
+            >
+              취소
+            </button>
+            <button
+              type="submit"
+              className="room-submit-button"
+              disabled={isPending}
+            >
+              {isPending ? '저장 중...' : '저장'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/phonebox/PhoneBoxGroup.tsx
+++ b/src/components/phonebox/PhoneBoxGroup.tsx
@@ -1,0 +1,106 @@
+import { PencilIcon, TrashIcon } from '../Icons';
+import { PHONE_BOX_GENDER_LABEL, sortStudents } from '../../utils/phone-box';
+import type { PhoneBoxGender, PhoneBoxResponse } from '../../types/api';
+
+const PREVIEW_LIMIT = 4;
+
+interface PhoneBoxGroupProps {
+  gender: PhoneBoxGender;
+  boxes: PhoneBoxResponse[];
+  onManageStudents: (box: PhoneBoxResponse) => void;
+  onRenameBox: (box: PhoneBoxResponse) => void;
+  onDeleteBox: (box: PhoneBoxResponse) => void;
+}
+
+export default function PhoneBoxGroup({
+  gender,
+  boxes,
+  onManageStudents,
+  onRenameBox,
+  onDeleteBox,
+}: PhoneBoxGroupProps) {
+  const totalStudents = boxes.reduce((sum, box) => sum + box.students.length, 0);
+
+  return (
+    <section className="floor-section">
+      <div className="floor-header">
+        <div>
+          <h2 className="floor-title">{PHONE_BOX_GENDER_LABEL[gender]}</h2>
+          <p className="floor-count">
+            {boxes.length}개 제출함 · {totalStudents}명 배정
+          </p>
+        </div>
+      </div>
+
+      <div className="phonebox-grid">
+        {boxes.map((box) => {
+          const students = sortStudents(box.students);
+          const preview = students.slice(0, PREVIEW_LIMIT);
+          const restCount = students.length - preview.length;
+
+          return (
+            <article key={box.id} className="phonebox-card">
+              <div className="phonebox-card-head">
+                <h3 className="phonebox-card-name">{box.name}</h3>
+                <span className={`phonebox-gender-badge ${box.gender.toLowerCase()}`}>
+                  {PHONE_BOX_GENDER_LABEL[box.gender]}
+                </span>
+              </div>
+
+              <p className="phonebox-card-count">
+                등록 학생 <strong>{students.length}</strong>명
+              </p>
+
+              <div className="phonebox-card-preview">
+                {preview.length > 0 ? (
+                  <>
+                    {preview.map((student) => (
+                      <span key={student.id} className="phonebox-student-chip">
+                        {student.room}호 {student.name}
+                      </span>
+                    ))}
+                    {restCount > 0 && (
+                      <span className="phonebox-student-chip more">
+                        외 {restCount}명
+                      </span>
+                    )}
+                  </>
+                ) : (
+                  <span className="phonebox-empty-preview">
+                    배정된 학생이 없습니다.
+                  </span>
+                )}
+              </div>
+
+              <div className="phonebox-card-actions">
+                <button
+                  type="button"
+                  className="phonebox-manage-button"
+                  onClick={() => onManageStudents(box)}
+                >
+                  학생 관리
+                </button>
+                <button
+                  type="button"
+                  className="phonebox-icon-button"
+                  aria-label={`${box.name} 이름 수정`}
+                  onClick={() => onRenameBox(box)}
+                >
+                  <PencilIcon className="phonebox-action-icon" />
+                </button>
+                <button
+                  type="button"
+                  className="phonebox-icon-button danger"
+                  aria-label={`${box.name} 삭제`}
+                  onClick={() => onDeleteBox(box)}
+                >
+                  <TrashIcon className="phonebox-action-icon" />
+                </button>
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/components/phonebox/PhoneBoxStudentModal.tsx
+++ b/src/components/phonebox/PhoneBoxStudentModal.tsx
@@ -1,0 +1,304 @@
+import { useMemo, useRef, useState } from 'react';
+import '../../styles/RoomModal.css';
+import '../../styles/Sleepover.css';
+import { matchesKoreanNameSearch } from '../../utils/korean-search';
+import {
+  GENDER_SHORT_LABEL,
+  PHONE_BOX_GENDER_LABEL,
+  canAssignStudent,
+  getStudentNumber,
+  sortStudents,
+} from '../../utils/phone-box';
+import type { PhoneBoxResponse, StudentResponse } from '../../types/api';
+
+const SEARCH_RESULT_LIMIT = 30;
+
+interface PhoneBoxStudentModalProps {
+  box: PhoneBoxResponse;
+  students: StudentResponse[];
+  isStudentsLoading: boolean;
+  isAdding: boolean;
+  isRemoving: boolean;
+  requestError: string;
+  onClose: () => void;
+  onAddStudents: (studentIds: number[]) => Promise<void>;
+  onRemoveStudent: (student: { id: number; name: string }) => void;
+}
+
+export default function PhoneBoxStudentModal({
+  box,
+  students,
+  isStudentsLoading,
+  isAdding,
+  isRemoving,
+  requestError,
+  onClose,
+  onAddStudents,
+  onRemoveStudent,
+}: PhoneBoxStudentModalProps) {
+  const backdropMouseDownRef = useRef(false);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [selectedIds, setSelectedIds] = useState<number[]>([]);
+  const [error, setError] = useState('');
+
+  const isPending = isAdding || isRemoving;
+
+  const assignedStudents = useMemo(
+    () => sortStudents(box.students),
+    [box.students],
+  );
+
+  const assignedIdSet = useMemo(
+    () => new Set(box.students.map((student) => student.id)),
+    [box.students],
+  );
+
+  /** 제출함 성별과 일치하는 학생만 후보로 노출 */
+  const eligibleStudents = useMemo(
+    () =>
+      sortStudents(
+        students.filter((student) =>
+          canAssignStudent(box.gender, student.gender),
+        ),
+      ),
+    [box.gender, students],
+  );
+
+  const searchResults = useMemo(() => {
+    const query = searchTerm.trim().toLowerCase();
+
+    if (!query) return eligibleStudents;
+
+    return eligibleStudents.filter((student) => {
+      const studentNumber = getStudentNumber(student);
+      return (
+        matchesKoreanNameSearch(student.name, searchTerm) ||
+        student.room.toLowerCase().includes(query) ||
+        studentNumber.includes(query)
+      );
+    });
+  }, [eligibleStudents, searchTerm]);
+
+  const visibleResults = searchResults.slice(0, SEARCH_RESULT_LIMIT);
+  const hiddenResultCount = searchResults.length - visibleResults.length;
+  const selectedIdSet = useMemo(() => new Set(selectedIds), [selectedIds]);
+
+  const requestClose = () => {
+    if (isPending) return;
+    onClose();
+  };
+
+  const handleToggleStudent = (studentId: number) => {
+    if (assignedIdSet.has(studentId)) return;
+
+    setSelectedIds((prev) =>
+      prev.includes(studentId)
+        ? prev.filter((id) => id !== studentId)
+        : [...prev, studentId],
+    );
+
+    if (error) setError('');
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+
+    if (selectedIds.length === 0) {
+      setError('추가할 학생을 선택해주세요.');
+      return;
+    }
+
+    setError('');
+
+    try {
+      await onAddStudents(selectedIds);
+      setSelectedIds([]);
+    } catch {
+      // 실패 시 선택을 유지해 다시 시도할 수 있도록 하고, 에러 메시지는 부모에서 표시한다.
+    }
+  };
+
+  return (
+    <div
+      className="room-modal-backdrop"
+      onMouseDown={(e) => {
+        if (isPending) return;
+        backdropMouseDownRef.current = e.target === e.currentTarget;
+      }}
+      onMouseUp={(e) => {
+        if (isPending) return;
+        if (e.target === e.currentTarget && backdropMouseDownRef.current) {
+          requestClose();
+        }
+        backdropMouseDownRef.current = false;
+      }}
+    >
+      <div className="room-modal phonebox-modal">
+        <div className="room-modal-header">
+          <div>
+            <p className="room-modal-eyebrow">Manage students</p>
+            <h2 className="room-modal-title">{box.name}</h2>
+            <p className="phonebox-modal-subtitle">
+              <span className={`phonebox-gender-badge ${box.gender.toLowerCase()}`}>
+                {PHONE_BOX_GENDER_LABEL[box.gender]}
+              </span>
+              등록 학생 {assignedStudents.length}명
+            </p>
+          </div>
+          <button
+            className="room-modal-close-button"
+            onClick={requestClose}
+            disabled={isPending}
+            type="button"
+            aria-label="모달 닫기"
+          >
+            ✕
+          </button>
+        </div>
+
+        <form className="phonebox-modal-form" onSubmit={handleSubmit}>
+          <div className="phonebox-modal-body">
+            <div className="room-form-group">
+              <label className="room-form-label" htmlFor="phonebox-student-search">
+                학생 추가
+              </label>
+              <input
+                id="phonebox-student-search"
+                type="text"
+                className="room-form-input"
+                placeholder="이름, 호실, 학번으로 검색"
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                disabled={isPending}
+                autoFocus
+              />
+              <p className="input-helper">
+                {box.gender === 'ALL'
+                  ? '모든 학생을 추가할 수 있습니다.'
+                  : `${PHONE_BOX_GENDER_LABEL[box.gender]} 제출함이므로 ${GENDER_SHORT_LABEL[box.gender]}학생만 추가할 수 있습니다.`}
+              </p>
+
+              <div className="sleepover-student-list phonebox-student-list">
+                {isStudentsLoading ? (
+                  <div className="sleepover-empty-option">
+                    학생 목록을 불러오는 중입니다.
+                  </div>
+                ) : visibleResults.length > 0 ? (
+                  visibleResults.map((student) => {
+                    const isAssigned = assignedIdSet.has(student.id);
+                    const isSelected = selectedIdSet.has(student.id);
+
+                    return (
+                      <button
+                        key={student.id}
+                        type="button"
+                        className={`sleepover-student-option ${isSelected ? 'selected' : ''} ${
+                          isAssigned ? 'assigned' : ''
+                        }`}
+                        onClick={() => handleToggleStudent(student.id)}
+                        disabled={isPending || isAssigned}
+                        aria-pressed={isSelected}
+                      >
+                        <span className="sleepover-student-main">
+                          {student.room}호 {student.name}
+                        </span>
+                        <span className="sleepover-student-meta">
+                          {isAssigned
+                            ? '추가됨'
+                            : `${getStudentNumber(student)} · ${GENDER_SHORT_LABEL[student.gender]}`}
+                        </span>
+                      </button>
+                    );
+                  })
+                ) : (
+                  <div className="sleepover-empty-option">
+                    {searchTerm
+                      ? '검색 결과가 없습니다.'
+                      : '추가할 수 있는 학생이 없습니다.'}
+                  </div>
+                )}
+              </div>
+
+              <div className="input-footer">
+                {error ? (
+                  <span className="error-text">{error}</span>
+                ) : (
+                  <span className="input-example">
+                    {hiddenResultCount > 0
+                      ? `외 ${hiddenResultCount}명 · 검색으로 좁혀보세요`
+                      : '여러 명을 선택해 한 번에 추가할 수 있습니다'}
+                  </span>
+                )}
+                <span className="char-count">{selectedIds.length}명 선택됨</span>
+              </div>
+            </div>
+
+            <div className="room-form-group">
+              <div className="phonebox-section-head">
+                <span className="room-form-label">
+                  등록된 학생 ({assignedStudents.length}명)
+                </span>
+              </div>
+
+              <div className="sleepover-student-list phonebox-student-list">
+                {assignedStudents.length > 0 ? (
+                  assignedStudents.map((student) => (
+                    <div key={student.id} className="phonebox-assigned-row">
+                      <span className="sleepover-student-main">
+                        {student.room}호 {student.name}
+                      </span>
+                      <span className="phonebox-assigned-meta">
+                        <span className="sleepover-student-meta">
+                          {getStudentNumber(student)} ·{' '}
+                          {GENDER_SHORT_LABEL[student.gender]}
+                        </span>
+                        <button
+                          type="button"
+                          className="phonebox-remove-button"
+                          onClick={() =>
+                            onRemoveStudent({ id: student.id, name: student.name })
+                          }
+                          disabled={isPending}
+                        >
+                          제거
+                        </button>
+                      </span>
+                    </div>
+                  ))
+                ) : (
+                  <div className="sleepover-empty-option">
+                    아직 등록된 학생이 없습니다.
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {requestError && (
+              <div className="sleepover-message error">{requestError}</div>
+            )}
+          </div>
+
+          <div className="room-modal-actions phonebox-modal-actions">
+            <button
+              type="button"
+              className="room-cancel-button"
+              onClick={requestClose}
+              disabled={isPending}
+            >
+              닫기
+            </button>
+            <button
+              type="submit"
+              className="room-submit-button"
+              disabled={isPending || selectedIds.length === 0}
+            >
+              {isAdding
+                ? '추가 중...'
+                : `${selectedIds.length > 0 ? `${selectedIds.length}명 ` : ''}추가`}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/phonebox/PhoneBoxToolbar.tsx
+++ b/src/components/phonebox/PhoneBoxToolbar.tsx
@@ -1,0 +1,75 @@
+import { SearchIcon } from '../Icons';
+import type { PhoneBoxGender } from '../../types/api';
+
+export type GenderFilter = 'ALL_BOXES' | PhoneBoxGender;
+
+const GENDER_FILTERS: { value: GenderFilter; label: string }[] = [
+  { value: 'ALL_BOXES', label: '전체' },
+  { value: 'MALE', label: '남기숙사' },
+  { value: 'FEMALE', label: '여기숙사' },
+];
+
+interface PhoneBoxToolbarProps {
+  searchTerm: string;
+  selectedGender: GenderFilter;
+  onSearchChange: (value: string) => void;
+  onGenderChange: (gender: GenderFilter) => void;
+  onCreateBox: () => void;
+}
+
+export default function PhoneBoxToolbar({
+  searchTerm,
+  selectedGender,
+  onSearchChange,
+  onGenderChange,
+  onCreateBox,
+}: PhoneBoxToolbarProps) {
+  return (
+    <section className="room-toolbar" aria-labelledby="phonebox-page-title">
+      <div className="room-toolbar-main">
+        <div>
+          <p className="room-eyebrow">Phone Box Management</p>
+          <h1 id="phonebox-page-title" className="room-title">
+            휴대폰 제출함 관리
+          </h1>
+        </div>
+        <button
+          type="button"
+          className="create-room-button"
+          onClick={onCreateBox}
+        >
+          제출함 추가
+        </button>
+      </div>
+
+      <div className="room-control-row">
+        <label className="room-search-box" htmlFor="phonebox-search">
+          <SearchIcon className="room-search-icon" />
+          <input
+            id="phonebox-search"
+            className="room-search-input"
+            type="search"
+            value={searchTerm}
+            onChange={(e) => onSearchChange(e.target.value)}
+            placeholder="제출함 이름 검색"
+          />
+        </label>
+
+        <div className="room-floor-filters" aria-label="기숙사 필터">
+          {GENDER_FILTERS.map((filter) => (
+            <button
+              key={filter.value}
+              type="button"
+              className={`floor-filter-button ${
+                selectedGender === filter.value ? 'active' : ''
+              }`}
+              onClick={() => onGenderChange(filter.value)}
+            >
+              {filter.label}
+            </button>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/pages/PhoneBox.tsx
+++ b/src/pages/PhoneBox.tsx
@@ -1,0 +1,313 @@
+import { useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import axios from 'axios';
+import ConfirmationModal from '../components/ConfirmationModal';
+import PhoneBoxCreateModal from '../components/phonebox/PhoneBoxCreateModal';
+import PhoneBoxEditModal from '../components/phonebox/PhoneBoxEditModal';
+import PhoneBoxGroup from '../components/phonebox/PhoneBoxGroup';
+import PhoneBoxStudentModal from '../components/phonebox/PhoneBoxStudentModal';
+import type { GenderFilter } from '../components/phonebox/PhoneBoxToolbar';
+import PhoneBoxToolbar from '../components/phonebox/PhoneBoxToolbar';
+import { phoneBoxService } from '../services/phone-box.service';
+import { studentService } from '../services/student.service';
+import { sortPhoneBoxes } from '../utils/phone-box';
+import '../styles/Room.css';
+import '../styles/PhoneBox.css';
+import type {
+  CreatePhoneBoxRequest,
+  PhoneBoxGender,
+  PhoneBoxResponse,
+} from '../types/api';
+
+const GROUP_ORDER: PhoneBoxGender[] = ['MALE', 'FEMALE', 'ALL'];
+
+type RemoveTarget = {
+  boxId: number;
+  student: { id: number; name: string };
+};
+
+const getErrorMessage = (error: unknown, fallback: string) => {
+  if (axios.isAxiosError(error)) {
+    const message = (error.response?.data as { message?: string } | undefined)
+      ?.message;
+    if (message) return message;
+  }
+  return fallback;
+};
+
+export default function PhoneBox() {
+  const queryClient = useQueryClient();
+  const [searchTerm, setSearchTerm] = useState('');
+  const [genderFilter, setGenderFilter] = useState<GenderFilter>('ALL_BOXES');
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+  const [editTargetId, setEditTargetId] = useState<number | null>(null);
+  const [manageTargetId, setManageTargetId] = useState<number | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<PhoneBoxResponse | null>(null);
+  const [removeTarget, setRemoveTarget] = useState<RemoveTarget | null>(null);
+
+  const genderParam = genderFilter === 'ALL_BOXES' ? undefined : genderFilter;
+
+  const {
+    data: boxes = [],
+    isLoading,
+    isError,
+  } = useQuery({
+    queryKey: ['phone-boxes', genderParam ?? 'all'],
+    queryFn: () => phoneBoxService.getPhoneBoxes(genderParam),
+  });
+
+  const { data: studentsData, isLoading: isStudentsLoading } = useQuery({
+    queryKey: ['students-all'],
+    queryFn: () => studentService.getStudents({ page: 0, size: 1000 }),
+    staleTime: 5 * 60 * 1000,
+    enabled: manageTargetId !== null,
+  });
+
+  const invalidatePhoneBoxes = () =>
+    queryClient.invalidateQueries({ queryKey: ['phone-boxes'] });
+
+  const createMutation = useMutation({
+    mutationFn: (data: CreatePhoneBoxRequest) =>
+      phoneBoxService.createPhoneBox(data),
+    onSuccess: () => {
+      invalidatePhoneBoxes();
+      setIsCreateModalOpen(false);
+    },
+  });
+
+  const renameMutation = useMutation({
+    mutationFn: ({ boxId, name }: { boxId: number; name: string }) =>
+      phoneBoxService.updatePhoneBoxName(boxId, { name }),
+    onSuccess: () => {
+      invalidatePhoneBoxes();
+      setEditTargetId(null);
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (boxId: number) => phoneBoxService.deletePhoneBox(boxId),
+    onSuccess: (_, boxId) => {
+      invalidatePhoneBoxes();
+      setDeleteTarget(null);
+      if (manageTargetId === boxId) setManageTargetId(null);
+    },
+  });
+
+  const addStudentsMutation = useMutation({
+    mutationFn: ({ boxId, studentIds }: { boxId: number; studentIds: number[] }) =>
+      phoneBoxService.addStudents(boxId, { studentIds }),
+    onSuccess: () => invalidatePhoneBoxes(),
+  });
+
+  const removeStudentsMutation = useMutation({
+    mutationFn: ({ boxId, studentIds }: { boxId: number; studentIds: number[] }) =>
+      phoneBoxService.removeStudents(boxId, { studentIds }),
+    onSuccess: () => {
+      invalidatePhoneBoxes();
+      setRemoveTarget(null);
+    },
+  });
+
+  const filteredBoxes = useMemo(() => {
+    const query = searchTerm.trim().toLowerCase();
+    const sorted = sortPhoneBoxes(boxes);
+
+    if (!query) return sorted;
+
+    return sorted.filter(
+      (box) =>
+        box.name.toLowerCase().includes(query) ||
+        box.students.some((student) =>
+          `${student.room} ${student.name}`.toLowerCase().includes(query),
+        ),
+    );
+  }, [boxes, searchTerm]);
+
+  const groups = useMemo(
+    () =>
+      GROUP_ORDER.map((gender) => ({
+        gender,
+        boxes: filteredBoxes.filter((box) => box.gender === gender),
+      })).filter((group) => group.boxes.length > 0),
+    [filteredBoxes],
+  );
+
+  const editTarget = boxes.find((box) => box.id === editTargetId) ?? null;
+  const manageTarget = boxes.find((box) => box.id === manageTargetId) ?? null;
+
+  const listErrorMessage = isError
+    ? '휴대폰 제출함 목록을 불러오지 못했습니다. 다시 시도해주세요.'
+    : deleteMutation.isError
+      ? getErrorMessage(
+          deleteMutation.error,
+          '제출함 삭제에 실패했습니다. 다시 시도해주세요.',
+        )
+      : '';
+
+  const studentModalError = addStudentsMutation.isError
+    ? getErrorMessage(
+        addStudentsMutation.error,
+        '학생 추가에 실패했습니다. 다시 시도해주세요.',
+      )
+    : removeStudentsMutation.isError
+      ? getErrorMessage(
+          removeStudentsMutation.error,
+          '학생 제거에 실패했습니다. 다시 시도해주세요.',
+        )
+      : '';
+
+  const handleCloseStudentModal = () => {
+    setManageTargetId(null);
+    addStudentsMutation.reset();
+    removeStudentsMutation.reset();
+  };
+
+  return (
+    <div className="room-page phonebox-page">
+      <div className="room-container">
+        <PhoneBoxToolbar
+          searchTerm={searchTerm}
+          selectedGender={genderFilter}
+          onSearchChange={setSearchTerm}
+          onGenderChange={setGenderFilter}
+          onCreateBox={() => {
+            createMutation.reset();
+            setIsCreateModalOpen(true);
+          }}
+        />
+
+        {listErrorMessage && (
+          <div className="room-error-banner">{listErrorMessage}</div>
+        )}
+
+        {isLoading ? (
+          <div className="room-loading">로딩 중...</div>
+        ) : boxes.length === 0 ? (
+          <div className="room-empty-state">
+            <strong>등록된 휴대폰 제출함이 없습니다.</strong>
+            <span>제출함을 추가하여 학생들을 배정하세요.</span>
+          </div>
+        ) : filteredBoxes.length === 0 ? (
+          <div className="room-empty-state">
+            <strong>조건에 맞는 제출함이 없습니다.</strong>
+            <span>검색어나 기숙사 필터를 다시 확인해주세요.</span>
+          </div>
+        ) : (
+          <div className="floor-sections">
+            {groups.map((group) => (
+              <PhoneBoxGroup
+                key={group.gender}
+                gender={group.gender}
+                boxes={group.boxes}
+                onManageStudents={(box) => {
+                  addStudentsMutation.reset();
+                  removeStudentsMutation.reset();
+                  setManageTargetId(box.id);
+                }}
+                onRenameBox={(box) => {
+                  renameMutation.reset();
+                  setEditTargetId(box.id);
+                }}
+                onDeleteBox={setDeleteTarget}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {isCreateModalOpen && (
+        <PhoneBoxCreateModal
+          defaultGender={genderParam ?? 'MALE'}
+          isPending={createMutation.isPending}
+          requestError={
+            createMutation.isError
+              ? getErrorMessage(
+                  createMutation.error,
+                  '제출함 생성에 실패했습니다. 다시 시도해주세요.',
+                )
+              : ''
+          }
+          onClose={() => setIsCreateModalOpen(false)}
+          onSubmit={(data) => createMutation.mutate(data)}
+        />
+      )}
+
+      {editTarget && (
+        <PhoneBoxEditModal
+          box={editTarget}
+          isPending={renameMutation.isPending}
+          requestError={
+            renameMutation.isError
+              ? getErrorMessage(
+                  renameMutation.error,
+                  '이름 수정에 실패했습니다. 다시 시도해주세요.',
+                )
+              : ''
+          }
+          onClose={() => setEditTargetId(null)}
+          onSubmit={(name) =>
+            renameMutation.mutate({ boxId: editTarget.id, name })
+          }
+        />
+      )}
+
+      {manageTarget && (
+        <PhoneBoxStudentModal
+          box={manageTarget}
+          students={studentsData?.content ?? []}
+          isStudentsLoading={isStudentsLoading}
+          isAdding={addStudentsMutation.isPending}
+          isRemoving={removeStudentsMutation.isPending}
+          requestError={studentModalError}
+          onClose={handleCloseStudentModal}
+          onAddStudents={async (studentIds) => {
+            await addStudentsMutation.mutateAsync({
+              boxId: manageTarget.id,
+              studentIds,
+            });
+          }}
+          onRemoveStudent={(student) =>
+            setRemoveTarget({ boxId: manageTarget.id, student })
+          }
+        />
+      )}
+
+      <ConfirmationModal
+        isOpen={Boolean(deleteTarget)}
+        eyebrow="Confirm action"
+        title="제출함 삭제"
+        message={`${deleteTarget?.name ?? ''} 제출함을 삭제하시겠습니까? 배정된 학생 ${
+          deleteTarget?.students.length ?? 0
+        }명도 함께 해제됩니다.`}
+        confirmText="삭제"
+        cancelText="취소"
+        confirmVariant="danger"
+        isConfirming={deleteMutation.isPending}
+        onConfirm={() => {
+          if (deleteTarget) deleteMutation.mutate(deleteTarget.id);
+        }}
+        onCancel={() => setDeleteTarget(null)}
+      />
+
+      <ConfirmationModal
+        isOpen={Boolean(removeTarget)}
+        eyebrow="Remove student"
+        title="학생 제거"
+        message={`${removeTarget?.student.name ?? ''} 학생을 제출함에서 제거하시겠습니까?`}
+        confirmText="제거"
+        cancelText="취소"
+        confirmVariant="danger"
+        isConfirming={removeStudentsMutation.isPending}
+        onConfirm={() => {
+          if (removeTarget) {
+            removeStudentsMutation.mutate({
+              boxId: removeTarget.boxId,
+              studentIds: [removeTarget.student.id],
+            });
+          }
+        }}
+        onCancel={() => setRemoveTarget(null)}
+      />
+    </div>
+  );
+}

--- a/src/services/phone-box.service.ts
+++ b/src/services/phone-box.service.ts
@@ -1,0 +1,40 @@
+import apiClient from '../lib/api-client';
+import type {
+  PhoneBoxResponse,
+  PhoneBoxGender,
+  CreatePhoneBoxRequest,
+  UpdatePhoneBoxNameRequest,
+  PhoneBoxStudentsRequest,
+} from '../types/api';
+
+export const phoneBoxService = {
+  getPhoneBoxes: async (gender?: PhoneBoxGender): Promise<PhoneBoxResponse[]> => {
+    const response = await apiClient.get<PhoneBoxResponse[]>('/teacher/phone-boxes', {
+      params: gender ? { gender } : undefined,
+    });
+    return response.data;
+  },
+
+  createPhoneBox: async (data: CreatePhoneBoxRequest): Promise<void> => {
+    await apiClient.post('/teacher/phone-boxes', data);
+  },
+
+  updatePhoneBoxName: async (
+    boxId: number,
+    data: UpdatePhoneBoxNameRequest
+  ): Promise<void> => {
+    await apiClient.patch(`/teacher/phone-boxes/${boxId}`, data);
+  },
+
+  deletePhoneBox: async (boxId: number): Promise<void> => {
+    await apiClient.delete(`/teacher/phone-boxes/${boxId}`);
+  },
+
+  addStudents: async (boxId: number, data: PhoneBoxStudentsRequest): Promise<void> => {
+    await apiClient.post(`/teacher/phone-boxes/${boxId}/students`, data);
+  },
+
+  removeStudents: async (boxId: number, data: PhoneBoxStudentsRequest): Promise<void> => {
+    await apiClient.post(`/teacher/phone-boxes/${boxId}/students/remove`, data);
+  },
+};

--- a/src/styles/PhoneBox.css
+++ b/src/styles/PhoneBox.css
@@ -1,0 +1,342 @@
+/* Phone Box Page - Room.css 레이아웃을 재사용하고 제출함 전용 요소만 정의 */
+.phonebox-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(272px, 1fr));
+  gap: 12px;
+}
+
+.phonebox-card {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 18px;
+  border: 1px solid #e6e6e7;
+  border-radius: 8px;
+  background: #fafafa;
+  transition:
+    border-color 0.2s,
+    background-color 0.2s,
+    box-shadow 0.2s;
+}
+
+.phonebox-card:hover {
+  border-color: #6d23ed;
+  background: #ffffff;
+  box-shadow: 0 8px 22px rgba(109, 35, 237, 0.1);
+}
+
+.phonebox-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.phonebox-card-name {
+  min-width: 0;
+  margin: 0;
+  overflow: hidden;
+  color: #0f0f10;
+  font-size: 16px;
+  font-weight: 800;
+  line-height: 1.3;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.phonebox-gender-badge {
+  flex-shrink: 0;
+  padding: 4px 10px;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.phonebox-gender-badge.male {
+  border-color: rgba(37, 99, 235, 0.2);
+  background: rgba(37, 99, 235, 0.08);
+  color: #2563eb;
+}
+
+.phonebox-gender-badge.female {
+  border-color: rgba(219, 39, 119, 0.2);
+  background: rgba(219, 39, 119, 0.08);
+  color: #db2777;
+}
+
+.phonebox-gender-badge.all {
+  border-color: rgba(109, 35, 237, 0.2);
+  background: rgba(109, 35, 237, 0.08);
+  color: #6d23ed;
+}
+
+.phonebox-card-count {
+  margin: 0;
+  color: #747678;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.phonebox-card-count strong {
+  color: #0f0f10;
+  font-weight: 800;
+}
+
+.phonebox-card-preview {
+  min-height: 30px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.phonebox-student-chip {
+  padding: 4px 9px;
+  border: 1px solid #e6e6e7;
+  border-radius: 6px;
+  background: #ffffff;
+  color: #5d5f60;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.phonebox-student-chip.more {
+  border-style: dashed;
+  color: #9e9e9f;
+}
+
+.phonebox-empty-preview {
+  color: #b0b2b4;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.phonebox-card-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: auto;
+  padding-top: 12px;
+  border-top: 1px solid #e6e6e7;
+}
+
+.phonebox-manage-button {
+  flex: 1;
+  min-height: 36px;
+  padding: 0 12px;
+  border: 1px solid #d7ccfb;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #6d23ed;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  transition:
+    border-color 0.2s,
+    background-color 0.2s;
+}
+
+.phonebox-manage-button:hover {
+  border-color: #6d23ed;
+  background: rgba(109, 35, 237, 0.08);
+}
+
+.phonebox-icon-button {
+  width: 36px;
+  height: 36px;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 1px solid #e6e6e7;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #5d5f60;
+  cursor: pointer;
+  transition:
+    border-color 0.2s,
+    background-color 0.2s,
+    color 0.2s;
+}
+
+.phonebox-icon-button:hover {
+  border-color: #6d23ed;
+  background: rgba(109, 35, 237, 0.05);
+  color: #6d23ed;
+}
+
+.phonebox-icon-button.danger:hover {
+  border-color: #ff4242;
+  background: #ff4242;
+  color: #ffffff;
+}
+
+.phonebox-action-icon {
+  width: 16px;
+  height: 16px;
+}
+
+/* 제출함 생성 모달 - 기숙사 선택 */
+.phonebox-gender-options {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.phonebox-gender-option {
+  min-height: 46px;
+  padding: 0 14px;
+  border: 1px solid #e6e6e7;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #5d5f60;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  transition:
+    border-color 0.2s,
+    background-color 0.2s,
+    color 0.2s,
+    opacity 0.2s;
+}
+
+.phonebox-gender-option:hover:not(:disabled) {
+  border-color: #6d23ed;
+  color: #6d23ed;
+}
+
+.phonebox-gender-option.active {
+  border-color: #6d23ed;
+  background: rgba(109, 35, 237, 0.08);
+  color: #6d23ed;
+}
+
+.phonebox-gender-option:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+/* 학생 관리 모달 */
+.phonebox-page .phonebox-modal {
+  width: min(640px, 100%);
+}
+
+.phonebox-modal-subtitle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 8px 0 0;
+  color: #747678;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.phonebox-modal-form {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.phonebox-modal-body {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 24px;
+  overflow-y: auto;
+}
+
+.phonebox-page .phonebox-modal-actions {
+  padding: 16px 24px;
+  border-top: 1px solid #e6e6e7;
+  background: #ffffff;
+}
+
+.phonebox-page .phonebox-student-list {
+  max-height: 232px;
+}
+
+.phonebox-page .sleepover-student-option.assigned:disabled {
+  border-style: dashed;
+  background: #f5f5f5;
+  color: #9e9e9f;
+  opacity: 1;
+}
+
+.phonebox-page .sleepover-student-option.assigned .sleepover-student-meta {
+  color: #6d23ed;
+}
+
+.phonebox-section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.phonebox-assigned-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 14px;
+  border: 1px solid #e6e6e7;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #0f0f10;
+}
+
+.phonebox-assigned-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.phonebox-remove-button {
+  border: 1px solid #ff4242;
+  background: transparent;
+  color: #ff4242;
+  padding: 4px 10px;
+  border-radius: 4px;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  transition:
+    background-color 0.2s,
+    color 0.2s,
+    opacity 0.2s;
+}
+
+.phonebox-remove-button:hover:not(:disabled) {
+  background: #ff4242;
+  color: #ffffff;
+}
+
+.phonebox-remove-button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+@media (max-width: 640px) {
+  .phonebox-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .phonebox-modal-body {
+    padding-left: 18px;
+    padding-right: 18px;
+  }
+
+  .phonebox-page .phonebox-modal-actions {
+    flex-direction: column-reverse;
+    padding-left: 18px;
+    padding-right: 18px;
+  }
+
+  .phonebox-assigned-row {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -266,6 +266,39 @@ export interface CreateRoomRequest {
   room: string;
 }
 
+// Phone Box Types
+export type PhoneBoxGender = 'MALE' | 'FEMALE' | 'ALL';
+
+export interface PhoneBoxStudent {
+  id: number;
+  name: string;
+  grade: number;
+  classroom: number;
+  number: number;
+  room: string;
+  gender: Gender;
+}
+
+export interface PhoneBoxResponse {
+  id: number;
+  name: string;
+  gender: PhoneBoxGender;
+  students: PhoneBoxStudent[];
+}
+
+export interface CreatePhoneBoxRequest {
+  name: string;
+  gender: PhoneBoxGender;
+}
+
+export interface UpdatePhoneBoxNameRequest {
+  name: string;
+}
+
+export interface PhoneBoxStudentsRequest {
+  studentIds: number[];
+}
+
 // Pagination Types
 export interface PageableObject {
   pageNumber: number;

--- a/src/utils/phone-box.ts
+++ b/src/utils/phone-box.ts
@@ -1,0 +1,44 @@
+import type { Gender, PhoneBoxGender, PhoneBoxResponse } from '../types/api';
+
+export const PHONE_BOX_GENDER_LABEL: Record<PhoneBoxGender, string> = {
+  MALE: '남기숙사',
+  FEMALE: '여기숙사',
+  ALL: '공용',
+};
+
+export const GENDER_SHORT_LABEL: Record<Gender, string> = {
+  MALE: '남',
+  FEMALE: '여',
+};
+
+/** 학번 (예: 1학년 2반 3번 -> 1203) */
+export const getStudentNumber = (student: {
+  grade: number;
+  classroom: number;
+  number: number;
+}) =>
+  `${student.grade}${student.classroom}${String(student.number).padStart(2, '0')}`;
+
+/** 제출함 성별과 학생 성별이 맞는지 검사 (공용 제출함은 모든 학생 허용) */
+export const canAssignStudent = (
+  boxGender: PhoneBoxGender,
+  studentGender: Gender,
+) => boxGender === 'ALL' || boxGender === studentGender;
+
+export const sortPhoneBoxes = (boxes: PhoneBoxResponse[]) =>
+  [...boxes].sort((a, b) =>
+    a.name.localeCompare(b.name, 'ko-KR', { numeric: true }),
+  );
+
+export const sortStudents = <
+  T extends { room: string; grade: number; classroom: number; number: number },
+>(
+  students: T[],
+) =>
+  [...students].sort((a, b) => {
+    const roomDiff = a.room.localeCompare(b.room, 'ko-KR', { numeric: true });
+    if (roomDiff !== 0) return roomDiff;
+    return getStudentNumber(a).localeCompare(getStudentNumber(b), 'ko-KR', {
+      numeric: true,
+    });
+  });


### PR DESCRIPTION
<!-- 관련 이슈가 있는 경우 "Closes #이슈번호" 형식으로 작성하면 머지 시 자동으로 이슈가 종료됩니다 -->
## Closes #62 

## 변경사항
<!-- 이번 작업에서 변경된 내용을 간단하게 작성해주세요 -->
- 휴대폰 제출함 관리 페이지 신규 추가 (`/phone-boxes`, 사이드바 "방 관리" 아래)
- 제출함 **생성 / 이름 수정 / 삭제** 기능 구현
- 제출함 목록을 **남기숙사 / 여기숙사** 필터로 조회 (서버 `gender` 파라미터 사용), 화면에서는 기숙사별로 그룹핑해 카드 목록으로 표시
- 제출함에 **학생 bulk 추가 / 제거** 기능 구현 (다중 선택 후 한 번에 요청)
- 제출함 성별과 일치하는 학생만 추가되도록 프론트에서도 필터링·검증 처리
- 제출함 API 연동 레이어 추가 (`phone-box.service.ts`, `types/api.ts`에 PhoneBox 타입)

## 스크린샷/동영상
<!-- UI 변경이 있는 경우에만 첨부해주세요 (선택) -->
<img width="1512" height="862" alt="스크린샷 2026-07-29 오전 10 12 51" src="https://github.com/user-attachments/assets/6b0b11d7-546e-44a3-85bc-65f9d7c6bce0" />
<img width="1509" height="861" alt="스크린샷 2026-07-29 오전 10 13 14" src="https://github.com/user-attachments/assets/68aea043-f3b7-4b0b-9a7c-934f9482ece0" />

## 참고 사항
<!-- 리뷰어가 알아두면 좋은 내용이나 작업하면서 고민했던 부분을 작성해주세요 (선택) -->
