### PR TITLE
hotfix: 배포 후 동적 모듈 로드 복구

### DIFF
--- a/public/staticwebapp.config.json
+++ b/public/staticwebapp.config.json
@@ -7,16 +7,10 @@
     {
       "route": "/assets/*",
       "headers": {
-        "cache-control": "public, max-age=31536000, immutable"
+        "Cache-Control": "public, max-age=31536000, immutable"
       }
     }
   ],
-  "responseOverrides": {
-    "404": {
-      "rewrite": "/index.html",
-      "statusCode": 200
-    }
-  },
   "mimeTypes": {
     ".js": "application/javascript",
     ".mjs": "application/javascript",
@@ -35,6 +29,7 @@
     ".html": "text/html"
   },
   "globalHeaders": {
+    "Cache-Control": "no-cache",
     "Content-Security-Policy": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://api.qvick.xyz https://devapi.qvick.xyz; font-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'",
     "Referrer-Policy": "strict-origin-when-cross-origin",
     "Permissions-Policy": "camera=(self), microphone=(), geolocation=()",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,20 @@ import { queryClient } from './lib/query-client'
 import { ToastProvider } from './components/Toast'
 import './index.css'
 
+const CHUNK_RELOAD_KEY = 'qvick:chunk-reload-at'
+const CHUNK_RELOAD_COOLDOWN_MS = 10_000
+
+// 새 배포로 이전 해시 청크가 사라진 경우 최신 index.html을 한 번 다시 불러옵니다.
+window.addEventListener('vite:preloadError', (event) => {
+  const lastReloadAt = Number(sessionStorage.getItem(CHUNK_RELOAD_KEY) ?? 0)
+
+  if (Date.now() - lastReloadAt < CHUNK_RELOAD_COOLDOWN_MS) return
+
+  event.preventDefault()
+  sessionStorage.setItem(CHUNK_RELOAD_KEY, String(Date.now()))
+  window.location.reload()
+})
+
 // 이전 버전에서 영구 저장된 토큰은 폐기하고 현재 탭 세션의 토큰만 사용합니다.
 localStorage.removeItem('accessToken')
 localStorage.removeItem('refreshToken')


### PR DESCRIPTION
## 변경사항
<!-- 이번 작업에서 변경된 내용을 간단하게 작성해주세요 -->

- 누락된 /assets/*.js가 HTML로 대체되지 않도록 404 설정 수정
- HTML은 no-cache, 해시 자산은 장기 캐시
- 청크 로드 실패 시 최신 버전으로 한 번 자동 새로고침
- 린트, 타입 검사, 빌드 통과