### PR TITLE
design :: #72 인원 확인 페이지 디자인 변경 (심야자습·휴대폰 제출·외박 포함)

### DIFF
--- a/src/pages/Check.tsx
+++ b/src/pages/Check.tsx
@@ -390,9 +390,9 @@ export default function Check() {
 
   useEffect(() => {
     setHeaderActions(
-      <div className="header-attendance-period-controls">
+      <div className="header-attendance-period-controls check-period-controls">
         <span
-          className={`header-attendance-period-summary ${
+          className={`header-attendance-period-summary check-period-summary ${
             isViewingCurrentAttendancePeriod ? 'is-current' : ''
           }`}
         >
@@ -402,19 +402,19 @@ export default function Check() {
           <span>{ATTENDANCE_PERIOD_LABELS[attendanceType].title}</span>
         </span>
         <div
-          className="header-attendance-period-navigation"
+          className="header-attendance-period-navigation check-period-navigation"
           aria-label="점호 회차 이동"
         >
           <button
             type="button"
-            className="header-attendance-period-button"
+            className="header-attendance-period-button check-period-button"
             onClick={handlePreviousAttendancePeriod}
           >
             ← 이전 점호
           </button>
           <button
             type="button"
-            className="header-attendance-period-button"
+            className="header-attendance-period-button check-period-button"
             onClick={handleNextAttendancePeriod}
           >
             다음 점호 →

--- a/src/pages/Check.tsx
+++ b/src/pages/Check.tsx
@@ -407,14 +407,14 @@ export default function Check() {
         >
           <button
             type="button"
-            className="header-attendance-period-button check-period-button"
+            className="header-attendance-period-button"
             onClick={handlePreviousAttendancePeriod}
           >
             ← 이전 점호
           </button>
           <button
             type="button"
-            className="header-attendance-period-button check-period-button"
+            className="header-attendance-period-button"
             onClick={handleNextAttendancePeriod}
           >
             다음 점호 →

--- a/src/pages/NightStudy.tsx
+++ b/src/pages/NightStudy.tsx
@@ -307,7 +307,7 @@ export default function NightStudy() {
           </thead>
           <tbody>
             {isLoading ? (
-              <tr>
+              <tr className="sleepover-empty-row">
                 <td colSpan={6} className="sleepover-empty-cell">
                   심야자습 현황을 불러오는 중입니다.
                 </td>
@@ -328,7 +328,7 @@ export default function NightStudy() {
                 </tr>
               ))
             ) : (
-              <tr>
+              <tr className="sleepover-empty-row">
                 <td colSpan={6} className="sleepover-empty-cell">
                   조건에 맞는 학생이 없습니다.
                 </td>

--- a/src/pages/PhoneSubmission.tsx
+++ b/src/pages/PhoneSubmission.tsx
@@ -325,7 +325,7 @@ export default function PhoneSubmission() {
           </thead>
           <tbody>
             {isLoading ? (
-              <tr>
+              <tr className="sleepover-empty-row">
                 <td colSpan={7} className="sleepover-empty-cell">
                   휴대폰 제출 현황을 불러오는 중입니다.
                 </td>
@@ -366,7 +366,7 @@ export default function PhoneSubmission() {
                 </tr>
               ))
             ) : (
-              <tr>
+              <tr className="sleepover-empty-row">
                 <td colSpan={7} className="sleepover-empty-cell">
                   조건에 맞는 학생이 없습니다.
                 </td>

--- a/src/pages/Sleepover.tsx
+++ b/src/pages/Sleepover.tsx
@@ -207,7 +207,7 @@ export default function Sleepover() {
           </thead>
           <tbody>
             {isLoading ? (
-              <tr>
+              <tr className="sleepover-empty-row">
                 <td colSpan={7} className="sleepover-empty-cell">
                   외박자 목록을 불러오는 중입니다.
                 </td>
@@ -249,7 +249,7 @@ export default function Sleepover() {
                 );
               })
             ) : (
-              <tr>
+              <tr className="sleepover-empty-row">
                 <td colSpan={7} className="sleepover-empty-cell">
                   외박자가 없습니다.
                 </td>

--- a/src/styles/Check.css
+++ b/src/styles/Check.css
@@ -614,7 +614,7 @@
   text-align: center;
 }
 
-.check-page .student-table tbody tr:not(:has(td[colspan])):hover td {
+.check-page .student-table tbody tr:not(.sleepover-empty-row):hover td {
   background: #fafafa;
 }
 
@@ -948,7 +948,7 @@
     background: #ffffff;
   }
 
-  .check-page .student-table tbody tr:not(:has(td[colspan])):hover td {
+  .check-page .student-table tbody tr:not(.sleepover-empty-row):hover td {
     background: transparent;
   }
 

--- a/src/styles/Check.css
+++ b/src/styles/Check.css
@@ -1,66 +1,99 @@
-/* Check Page Styles */
+/* =========================================================
+   Check Page 공용 스타일
+   - 인원 확인 / 심야자습 / 휴대폰 제출 / (외박·자치위원) 페이지가 공유
+   - 모든 선택자는 .check-page 하위로 스코핑하여 전역 오염 방지
+   ========================================================= */
+
 .check-page {
+  min-height: 100%;
   padding: 32px 40px;
+  background: #fafafa;
 }
 
+/* 콘텐츠 최대폭 1180px 중앙정렬 */
+.check-page .controls-section,
+.check-page .filter-section,
+.check-page .table-container,
+.check-page .check-skeleton {
+  width: min(1180px, 100%);
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.check-page .check-skeleton {
+  margin-bottom: 32px;
+}
+
+/* ===== 상단 컨트롤 (날짜 · 검색 · 통계) ===== */
 .check-page .controls-section {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 24px;
-  gap: 24px;
+  gap: 20px;
+  margin-bottom: 32px;
 }
 
 .check-page .controls-left {
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: 12px;
 }
 
 .check-page .date-picker input {
-  padding: 10px 16px;
-  border: 2px solid #e6e6e7;
-  border-radius: 12px;
-  font-size: 15px;
-  font-weight: 500;
-  color: #0f0f10;
+  min-height: 40px;
+  padding: 8px 12px;
+  border: 1px solid #e4e4e7;
+  border-radius: 10px;
   background: #ffffff;
+  font-size: 13px;
+  font-weight: 600;
+  color: #0f0f10;
   cursor: pointer;
-  transition: all 0.2s;
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
 }
 
 .check-page .date-picker input:hover {
-  border-color: #6d23ed;
+  border-color: #c9c9cc;
 }
 
 .check-page .date-picker input:focus {
   outline: none;
   border-color: #6d23ed;
-  box-shadow: 0 0 0 3px rgba(109, 35, 237, 0.1);
+  box-shadow: 0 0 0 3px rgba(109, 35, 237, 0.12);
 }
 
 .check-page .search-box {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
+  width: 280px;
+  min-height: 40px;
+  padding: 0 14px;
+  border: 1px solid #e4e4e7;
+  border-radius: 10px;
   background: #ffffff;
-  border: 2px solid #e6e6e7;
-  border-radius: 12px;
-  padding: 10px 16px;
-  width: 300px;
-  transition: all 0.2s;
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+.check-page .search-box:hover {
+  border-color: #c9c9cc;
 }
 
 .check-page .search-box:focus-within {
   border-color: #6d23ed;
-  box-shadow: 0 0 0 3px rgba(109, 35, 237, 0.1);
+  box-shadow: 0 0 0 3px rgba(109, 35, 237, 0.12);
 }
 
-.search-icon {
-  width: 20px;
-  height: 20px;
+.check-page .search-icon {
+  width: 18px;
+  height: 18px;
   flex-shrink: 0;
-  color: #9e9e9f;
+  color: #a1a1aa;
+  transition: color 0.15s ease;
 }
 
 .check-page .search-box:focus-within .search-icon {
@@ -70,18 +103,20 @@
 .check-page .search-box input {
   border: none;
   background: transparent;
-  font-size: 15px;
+  font-size: 13px;
   font-weight: 500;
   color: #0f0f10;
   outline: none;
   flex: 1;
+  min-width: 0;
 }
 
 .check-page .search-box input::placeholder {
-  color: #9e9e9f;
-  font-weight: 400;
+  color: #a1a1aa;
+  font-weight: 500;
 }
 
+/* 통계 박스 */
 .check-page .stats-section {
   display: flex;
   gap: 10px;
@@ -92,215 +127,233 @@
 }
 
 .check-page .stat-box {
+  padding: 12px 16px;
+  border: 1px solid #e5e5e5;
+  border-radius: 12px;
   background: #ffffff;
-  padding: 7px 20px;
-  border-radius: 8px;
-  font-size: 16px;
-  font-weight: 500;
+  font-size: 13px;
+  font-weight: 600;
+  color: #52525b;
   white-space: nowrap;
+  transition: border-color 0.15s ease;
+}
+
+.check-page .stat-box:hover {
+  border-color: #c9c9cc;
 }
 
 .check-page .stat-box .positive {
-  color: #00bf40;
+  color: #22c55e;
+  font-weight: 700;
 }
 
 .check-page .stat-box .negative {
-  color: #e1322e;
+  color: #ef4444;
+  font-weight: 700;
 }
 
 .check-page .stat-box .warning {
   color: #f59e0b;
+  font-weight: 700;
 }
 
 .check-page .stat-box .sleepover-count {
   color: #8b5cf6;
+  font-weight: 700;
 }
 
 .check-page .stat-box .phone-submission-count {
-  color: #e1322e;
-}
-
-.check-page .excel-button {
-  min-height: 38px;
-  background: #164e8d;
-  color: #ffffff;
-  border: 1px solid #164e8d;
-  border-radius: 8px;
-  padding: 0 14px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  font-size: 14px;
+  color: #ef4444;
   font-weight: 700;
-  cursor: pointer;
-  transition:
-    background-color 0.2s,
-    border-color 0.2s,
-    opacity 0.2s;
-  white-space: nowrap;
 }
 
-.check-page .excel-button:hover {
-  background: #1a5aa1;
-  border-color: #1a5aa1;
-}
-
-.check-page .excel-button:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-}
-
+/* ===== 엑셀 내보내기 드롭다운 ===== */
 .check-page .excel-dropdown {
   position: relative;
 }
 
-.excel-menu {
+.check-page .excel-button {
+  min-height: 40px;
+  padding: 0 16px;
+  border: 1px solid #6d23ed;
+  border-radius: 8px;
+  background: #6d23ed;
+  color: #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  white-space: nowrap;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease,
+    opacity 0.15s ease;
+}
+
+.check-page .excel-button:hover:not(:disabled) {
+  background: #5919c7;
+  border-color: #5919c7;
+}
+
+.check-page .excel-button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.check-page .excel-icon {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  color: #ffffff;
+}
+
+.check-page .excel-caret {
+  font-size: 11px;
+  line-height: 1;
+}
+
+.check-page .excel-menu {
   position: absolute;
   top: 100%;
   right: 0;
-  margin-top: 8px;
-  padding: 8px;
-  background: #ffffff;
-  border: 1px solid #e6e6e7;
-  border-radius: 8px;
-  box-shadow: 0 16px 36px rgba(15, 15, 16, 0.16);
   z-index: 10;
-  min-width: 220px;
+  min-width: 240px;
+  margin-top: 8px;
+  padding: 6px;
+  border: 1px solid #e5e5e5;
+  border-radius: 10px;
+  background: #ffffff;
+  box-shadow: 0 12px 28px rgba(15, 15, 16, 0.1);
 }
 
-.excel-menu-header {
+.check-page .excel-menu-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
   padding: 8px 10px 10px;
-  font-size: 13px;
-  font-weight: 800;
+  border-bottom: 1px solid #ececef;
   color: #6d23ed;
-  border-bottom: 1px solid #e5e7eb;
+  font-size: 12px;
+  font-weight: 800;
 }
 
-.excel-menu-header-action {
+.check-page .excel-menu-header-action {
+  padding: 2px 6px;
   border: none;
+  border-radius: 6px;
   background: transparent;
   color: #747678;
   font-size: 12px;
   font-weight: 700;
   cursor: pointer;
+  transition: color 0.15s ease, background-color 0.15s ease;
 }
 
-.excel-menu-header-action:hover {
+.check-page .excel-menu-header-action:hover {
   color: #6d23ed;
+  background: rgba(109, 35, 237, 0.06);
 }
 
-.excel-menu-item {
+.check-page .excel-menu-item {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 3px;
   width: 100%;
-  padding: 12px;
-  background: #ffffff;
+  padding: 10px 12px;
   border: 1px solid transparent;
   border-radius: 8px;
-  font-size: 14px;
+  background: #ffffff;
+  color: #0f0f10;
+  font-size: 13px;
   font-weight: 700;
-  color: #1f2937;
-  cursor: pointer;
   text-align: left;
+  cursor: pointer;
   transition:
-    background-color 0.2s,
-    border-color 0.2s,
-    color 0.2s;
+    background-color 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease;
 }
 
-.excel-menu-item:hover {
+.check-page .excel-menu-item:hover {
   border-color: rgba(109, 35, 237, 0.18);
   background: rgba(109, 35, 237, 0.06);
 }
 
-.excel-menu-item + .excel-menu-item {
-  margin-top: 6px;
+.check-page .excel-menu-item + .excel-menu-item {
+  margin-top: 4px;
 }
 
-.excel-menu-item.absent-only {
-  color: #e1322e;
+.check-page .excel-menu-item-title {
+  font-size: 13px;
+  font-weight: 700;
 }
 
-.excel-menu-item.absent-only:hover {
-  border-color: rgba(225, 50, 46, 0.2);
-  background: rgba(225, 50, 46, 0.08);
-}
-
-.excel-menu-item.sleepover-only {
-  color: #6d23ed;
-}
-
-.excel-menu-item.sleepover-only:hover {
-  border-color: rgba(109, 35, 237, 0.22);
-  background: rgba(109, 35, 237, 0.08);
-}
-
-.excel-menu-item-title {
-  font-size: 14px;
-  font-weight: 800;
-}
-
-.excel-menu-item-desc {
+.check-page .excel-menu-item-desc {
   color: #747678;
   font-size: 12px;
   font-weight: 600;
   line-height: 1.35;
 }
 
-.excel-menu-item.back-button {
+.check-page .excel-menu-item.absent-only {
+  color: #b91c1c;
+}
+
+.check-page .excel-menu-item.absent-only:hover {
+  border-color: rgba(239, 68, 68, 0.2);
+  background: rgba(239, 68, 68, 0.07);
+}
+
+.check-page .excel-menu-item.sleepover-only {
+  color: #6d28d9;
+}
+
+.check-page .excel-menu-item.sleepover-only:hover {
+  border-color: rgba(139, 92, 246, 0.24);
+  background: rgba(139, 92, 246, 0.08);
+}
+
+.check-page .excel-menu-item.back-button {
   align-items: center;
+  padding: 8px 12px;
+  background: #f4f4f5;
   color: #747678;
   font-size: 13px;
-  padding: 9px 12px;
-  background: #f7f7f8;
+  font-weight: 600;
 }
 
-.excel-icon {
-  width: 18px;
-  height: 18px;
-  flex-shrink: 0;
-  color: #ffffff;
+.check-page .excel-menu-item.back-button:hover {
+  border-color: transparent;
+  background: #ececef;
 }
 
-.excel-caret {
-  font-size: 11px;
-  line-height: 1;
-}
-
-/* Filter Section */
+/* ===== 필터 섹션 ===== */
 .check-page .filter-section {
   display: flex;
-  gap: 20px;
-  margin-bottom: 20px;
-  padding: 20px;
-  background: #ffffff;
-  border-radius: 12px;
+  align-items: center;
+  gap: 20px 24px;
   flex-wrap: wrap;
-  align-items: center;
-}
-
-.check-page .filter-actions {
-  margin-left: auto;
-  display: flex;
-  align-items: center;
+  padding: 16px 20px;
+  margin-bottom: 32px;
+  border: 1px solid #e5e5e5;
+  border-radius: 12px;
+  background: #ffffff;
 }
 
 .check-page .filter-group {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 10px;
 }
 
-.filter-label {
-  font-size: 15px;
+.check-page .filter-label {
+  color: #747678;
+  font-size: 13px;
   font-weight: 600;
-  color: #0f0f10;
   white-space: nowrap;
 }
 
@@ -310,22 +363,25 @@
 }
 
 .check-page .filter-btn {
-  padding: 6px 16px;
-  border: 1px solid #e6e6e7;
-  background: #ffffff;
-  color: #5d5f60;
+  padding: 7px 14px;
+  border: 1px solid #e4e4e7;
   border-radius: 8px;
-  font-size: 14px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.2s;
+  background: #ffffff;
+  color: #52525b;
+  font-size: 13px;
+  font-weight: 600;
   white-space: nowrap;
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease;
 }
 
 .check-page .filter-btn:hover {
-  border-color: #6d23ed;
-  color: #6d23ed;
-  background: rgba(109, 35, 237, 0.05);
+  border-color: #d4d4d8;
+  background: #f4f4f5;
+  color: #3f3f46;
 }
 
 .check-page .filter-btn.active {
@@ -335,14 +391,23 @@
 }
 
 .check-page .filter-btn.active:hover {
-  background: #5919c7;
   border-color: #5919c7;
+  background: #5919c7;
+  color: #ffffff;
 }
 
+.check-page .filter-actions {
+  display: flex;
+  align-items: center;
+  margin-left: auto;
+}
+
+/* ===== 학생 테이블 ===== */
 .check-page .table-container {
-  background: #ffffff;
-  border-radius: 8px;
   overflow: hidden;
+  border: 1px solid #e5e5e5;
+  border-radius: 12px;
+  background: #ffffff;
 }
 
 .check-page .student-table {
@@ -502,47 +567,55 @@
 }
 
 .check-page .student-table thead th {
-  background: #ffffff;
-  border-bottom: 1px solid #c4c5c6;
-  padding: 13.5px 6px;
-  font-size: 15px;
+  padding: 12px 8px;
+  border-bottom: 1px solid #ececef;
+  background: #fafafa;
+  color: #747678;
+  font-size: 13px;
   font-weight: 600;
-  color: #0f0f10;
   text-align: center;
+  white-space: nowrap;
 }
 
 .check-page .student-table thead th.sortable {
-  cursor: pointer;
-  user-select: none;
   position: relative;
-  transition: background-color 0.2s;
   padding-left: 18px;
   padding-right: 18px;
+  cursor: pointer;
+  user-select: none;
+  transition: background-color 0.15s ease, color 0.15s ease;
 }
 
 .check-page .student-table thead th.sortable:hover {
-  background: #f5f5f5;
+  background: #f4f4f5;
+  color: #3f3f46;
 }
 
 .check-page .student-table thead th.sortable:active {
-  background: #eeeeee;
+  background: #ececef;
 }
 
-.sort-indicator {
-  font-size: 12px;
-  color: #6d23ed;
+.check-page .sort-indicator {
   position: absolute;
   right: 8px;
   top: 50%;
   transform: translateY(-50%);
+  color: #6d23ed;
+  font-size: 11px;
+  line-height: 1;
 }
 
 .check-page .student-table tbody td {
-  padding: 12px 6px;
-  border-bottom: 1px solid #c4c5c6;
-  font-size: 16px;
+  padding: 13px 8px;
+  border-bottom: 1px solid #f4f4f5;
+  color: #3f3f46;
+  font-size: 13px;
+  font-weight: 500;
   text-align: center;
-  color: #0f0f10;
+}
+
+.check-page .student-table tbody tr:not(:has(td[colspan])):hover td {
+  background: #fafafa;
 }
 
 .check-page .student-table thead th:first-child,
@@ -561,120 +634,186 @@
   border-bottom: none;
 }
 
-.room-cell {
-  font-weight: 500;
-}
-
-.status-present {
-  color: #00bf40;
+.check-page .room-cell {
+  color: #0f0f10;
   font-weight: 600;
 }
 
-.status-absent {
-  color: #ff4242;
+/* 상태 텍스트 (출석/미출석/지연/외박) */
+.check-page .status-present {
+  color: #22c55e;
   font-weight: 600;
 }
 
-.status-sleepover {
+.check-page .status-absent {
+  color: #ef4444;
+  font-weight: 600;
+}
+
+.check-page .status-sleepover {
   color: #8b5cf6;
   font-weight: 600;
 }
 
-.status-late {
+.check-page .status-late {
   color: #f59e0b;
   font-weight: 600;
 }
 
+/* 행 내 상태 셀렉트 */
 .check-page .status-select {
-  border: none;
+  padding: 6px 10px;
+  border: 1px solid transparent;
+  border-radius: 8px;
   background: transparent;
-  font-size: 14px;
-  font-weight: 600;
+  color: #3f3f46;
+  font-size: 13px;
+  font-weight: 700;
   cursor: pointer;
-  padding: 2px 4px;
-  border-radius: 4px;
   outline: none;
   appearance: auto;
   text-align: center;
   text-align-last: center;
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease;
 }
 
 .check-page .status-select:disabled {
-  opacity: 0.6;
+  opacity: 0.55;
   cursor: not-allowed;
 }
 
 .check-page .status-select.status-present {
-  color: #00bf40;
+  color: #15803d;
+  background: rgba(34, 197, 94, 0.12);
 }
 
 .check-page .status-select.status-absent {
-  color: #ff4242;
+  color: #b91c1c;
+  background: rgba(239, 68, 68, 0.09);
 }
 
 .check-page .status-select.status-sleepover {
-  color: #8b5cf6;
+  color: #6d28d9;
+  background: rgba(139, 92, 246, 0.12);
 }
 
 .check-page .status-select.status-late {
-  color: #f59e0b;
+  color: #b45309;
+  background: rgba(245, 158, 11, 0.14);
 }
 
+/* 휴대폰 제출 셀렉트 */
 .check-page .phone-submission-select {
-  border: none;
+  padding: 6px 10px;
+  border: 1px solid transparent;
+  border-radius: 8px;
   background: transparent;
-  font-size: 14px;
-  font-weight: 600;
+  color: #3f3f46;
+  font-size: 13px;
+  font-weight: 700;
   cursor: pointer;
-  padding: 2px 4px;
-  border-radius: 4px;
   outline: none;
   appearance: auto;
   text-align: center;
   text-align-last: center;
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease;
 }
 
 .check-page .phone-submission-select:disabled {
-  opacity: 0.6;
+  opacity: 0.55;
   cursor: not-allowed;
 }
 
 .check-page .phone-submission-select.status-present {
-  color: #00bf40;
+  color: #15803d;
+  background: rgba(34, 197, 94, 0.12);
 }
 
 .check-page .phone-submission-select.status-absent {
-  color: #ff4242;
+  color: #b91c1c;
+  background: rgba(239, 68, 68, 0.09);
 }
 
 .check-page .phone-submission-select.status-sleepover {
-  color: #8b5cf6;
+  color: #6d28d9;
+  background: rgba(139, 92, 246, 0.12);
 }
 
-.phone-submission-badge {
+/* 휴대폰 제출 뱃지 (O / X / 외박 / -) */
+.check-page .phone-submission-badge {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 15px;
-  font-weight: 600;
-  line-height: 1;
+  padding: 3px 10px;
+  border-radius: 999px;
+  color: #747678;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.4;
   white-space: nowrap;
 }
 
-.phone-submission-badge.submitted {
-  color: #00a83a;
+.check-page .phone-submission-badge.submitted {
+  color: #15803d;
+  background: rgba(34, 197, 94, 0.12);
 }
 
-.phone-submission-badge.not-submitted {
-  color: #e1322e;
+.check-page .phone-submission-badge.not-submitted {
+  color: #b91c1c;
+  background: rgba(239, 68, 68, 0.09);
 }
 
-.phone-submission-badge.sleepover {
-  color: #6d23ed;
+.check-page .phone-submission-badge.sleepover {
+  color: #6d28d9;
+  background: rgba(139, 92, 246, 0.12);
 }
 
-.phone-submission-badge.unknown {
+.check-page .phone-submission-badge.unknown {
   color: #747678;
+  background: #f4f4f5;
+}
+
+/* 점호 회차 이동 컨트롤 (헤더 영역, Header.css 보조 정의) */
+.header-attendance-period-controls.check-period-controls {
+  gap: 10px;
+}
+
+.header-attendance-period-summary.check-period-summary {
+  color: #52525b;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.header-attendance-period-summary.check-period-summary.is-current {
+  color: #6d23ed;
+  font-weight: 700;
+}
+
+.header-attendance-period-summary.check-period-summary.is-current
+  .header-attendance-period-date {
+  background: #ede9fe;
+}
+
+.header-attendance-period-navigation.check-period-navigation {
+  padding: 3px 5px;
+  border: 1px solid #e4e4e7;
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.header-attendance-period-navigation.check-period-navigation
+  .header-attendance-period-button {
+  color: #52525b;
+}
+
+.header-attendance-period-navigation.check-period-navigation
+  .header-attendance-period-button:hover {
+  background: #ede9fe;
+  color: #6d23ed;
 }
 
 /* 반응형 디자인 */
@@ -686,6 +825,7 @@
   .check-page .controls-section {
     flex-direction: column;
     align-items: stretch;
+    margin-bottom: 24px;
   }
 
   .check-page .controls-left {
@@ -702,7 +842,7 @@
   }
 
   .check-page .stats-section {
-    flex-wrap: wrap;
+    justify-content: flex-start;
   }
 
   .check-page .stat-box {
@@ -713,6 +853,7 @@
   .check-page .filter-section {
     flex-direction: column;
     align-items: stretch;
+    margin-bottom: 24px;
   }
 
   .check-page .filter-group {
@@ -751,8 +892,11 @@
   .check-page .stats-section {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    width: 100%;
     gap: 8px;
+  }
+
+  .check-page .stat-box {
+    text-align: center;
   }
 
   .check-page .filter-section {
@@ -772,8 +916,10 @@
   }
 
   .check-page .table-container {
-    background: transparent;
     overflow: visible;
+    border: none;
+    border-radius: 0;
+    background: transparent;
   }
 
   .check-page .student-table,
@@ -797,10 +943,13 @@
 
   .check-page .student-table tbody tr {
     padding: 14px;
-    border: 1px solid #e6e6e7;
+    border: 1px solid #e5e5e5;
     border-radius: 12px;
     background: #ffffff;
-    box-shadow: 0 8px 20px rgba(15, 15, 16, 0.06);
+  }
+
+  .check-page .student-table tbody tr:not(:has(td[colspan])):hover td {
+    background: transparent;
   }
 
   .check-page .student-table tbody td {
@@ -809,16 +958,16 @@
     justify-content: space-between;
     gap: 16px;
     padding: 10px 0;
-    border-bottom: 1px solid #f0f0f1;
-    font-size: 15px;
+    border-bottom: 1px solid #f4f4f5;
+    font-size: 13px;
     text-align: right;
   }
 
   .check-page .student-table tbody td::before {
     content: attr(data-label);
     color: #747678;
-    font-size: 13px;
-    font-weight: 700;
+    font-size: 12px;
+    font-weight: 600;
     text-align: left;
   }
 
@@ -839,7 +988,6 @@
     max-width: 160px;
     text-align: right;
   }
-
 }
 
 @media (max-width: 480px) {
@@ -848,12 +996,12 @@
   }
 
   .check-page .stat-box {
-    font-size: 14px;
-    padding: 8px 10px;
+    padding: 10px 12px;
+    font-size: 12px;
   }
 
   .check-page .excel-button {
-    font-size: 16px;
+    font-size: 13px;
     padding: 8px 10px;
   }
 
@@ -871,5 +1019,4 @@
   .check-page .status-select {
     max-width: 100%;
   }
-
 }

--- a/src/styles/Sleepover.css
+++ b/src/styles/Sleepover.css
@@ -1,166 +1,128 @@
+/* =========================================================
+   Sleepover Page 스타일
+   - 외박 확인 / 심야자습 / 휴대폰 제출 페이지가 공유하는 버튼·배너·모달 요소
+   - 페이지 고유 클래스(.sleepover-page)와 .check-page 하위로 스코핑
+   ========================================================= */
+
+/* ===== 액션 버튼 ===== */
 .sleepover-page .sleepover-primary-button,
 .sleepover-page .sleepover-secondary-button {
-  min-height: 38px;
-  padding: 0 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 40px;
+  padding: 0 14px;
   border-radius: 8px;
-  font-size: 14px;
-  font-weight: 700;
+  font-size: 13px;
+  font-weight: 600;
+  white-space: nowrap;
   cursor: pointer;
   transition:
-    background-color 0.2s,
-    border-color 0.2s,
-    color 0.2s,
-    opacity 0.2s;
-  white-space: nowrap;
+    background-color 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease,
+    opacity 0.15s ease;
 }
 
 .sleepover-page .sleepover-primary-button {
-  border: none;
+  border: 1px solid #6d23ed;
   background: #6d23ed;
   color: #ffffff;
 }
 
 .sleepover-page .sleepover-primary-button:hover:not(:disabled) {
+  border-color: #5919c7;
   background: #5919c7;
 }
 
 .sleepover-page .sleepover-secondary-button {
-  border: 1px solid #6d23ed;
+  border: 1px solid #e4e4e7;
   background: #ffffff;
-  color: #6d23ed;
+  color: #52525b;
 }
 
 .sleepover-page .sleepover-secondary-button:hover:not(:disabled) {
-  background: rgba(109, 35, 237, 0.08);
+  border-color: #d4d4d8;
+  background: #f4f4f5;
+  color: #3f3f46;
 }
 
 .sleepover-page .sleepover-primary-button:disabled,
-.sleepover-page .sleepover-secondary-button:disabled,
-.sleepover-delete-button:disabled {
+.sleepover-page .sleepover-secondary-button:disabled {
   opacity: 0.55;
   cursor: not-allowed;
 }
 
-.sleepover-message {
-  margin-bottom: 16px;
+/* ===== 동기화 결과 / 에러 배너 ===== */
+.check-page .sleepover-message {
+  width: min(1180px, 100%);
+  margin-left: auto;
+  margin-right: auto;
+  margin-bottom: 24px;
   padding: 12px 16px;
-  border: 1px solid rgba(109, 35, 237, 0.2);
-  border-radius: 8px;
-  background: #f6f2ff;
+  border: 1px solid rgba(109, 35, 237, 0.25);
+  border-radius: 10px;
+  background: #ede9fe;
   color: #4a19a8;
-  font-size: 14px;
-  font-weight: 700;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.5;
 }
 
-.sleepover-message.error {
-  border-color: rgba(255, 66, 66, 0.22);
-  background: rgba(255, 66, 66, 0.08);
-  color: #e1322e;
+.check-page .sleepover-message.error {
+  border-color: rgba(239, 68, 68, 0.28);
+  background: rgba(239, 68, 68, 0.08);
+  color: #b91c1c;
 }
 
-.sleepover-reason-cell {
+/* ===== 외박자 목록 테이블 ===== */
+.sleepover-page .sleepover-reason-cell {
   max-width: 280px;
+  color: #52525b;
+  font-size: 13px;
   line-height: 1.5;
   word-break: keep-all;
 }
 
-.sleepover-empty-cell {
-  height: 180px;
-  color: #747678;
-  font-weight: 600;
-}
-
-.sleepover-delete-button {
-  border: 1px solid #ff4242;
-  background: transparent;
-  color: #ff4242;
-  padding: 4.5px 12px;
-  border-radius: 4px;
-  font-size: 15px;
-  cursor: pointer;
-  transition:
-    background-color 0.2s,
-    color 0.2s,
-    opacity 0.2s;
-}
-
-.sleepover-delete-button:hover:not(:disabled) {
-  background: #ff4242;
-  color: #ffffff;
-}
-
-.sleepover-modal {
-  width: min(620px, 100%);
-}
-
-.sleepover-student-list {
-  max-height: 260px;
-  overflow-y: auto;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 4px 2px;
-}
-
-.sleepover-student-option {
-  width: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 12px 14px;
-  border: 1px solid #e6e6e7;
-  border-radius: 8px;
+.sleepover-page .sleepover-empty-cell {
+  padding: 48px 16px;
   background: #ffffff;
-  color: #0f0f10;
-  cursor: pointer;
-  transition:
-    border-color 0.2s,
-    background-color 0.2s,
-    color 0.2s;
-}
-
-.sleepover-student-option:hover:not(:disabled),
-.sleepover-student-option.selected {
-  border-color: #6d23ed;
-  background: rgba(109, 35, 237, 0.06);
-}
-
-.sleepover-student-option:disabled {
-  opacity: 0.55;
-  cursor: not-allowed;
-}
-
-.sleepover-student-main {
-  font-size: 14px;
-  font-weight: 800;
-}
-
-.sleepover-student-meta {
   color: #747678;
   font-size: 13px;
-  font-weight: 700;
-  white-space: nowrap;
-}
-
-.sleepover-empty-option {
-  padding: 14px;
-  border: 1px dashed #d6d6d8;
-  border-radius: 8px;
-  color: #747678;
-  font-size: 14px;
   font-weight: 600;
   text-align: center;
 }
 
-.sleepover-reason-input {
-  min-height: 92px;
-  padding-top: 12px;
-  padding-bottom: 12px;
-  resize: vertical;
-  line-height: 1.5;
+.sleepover-page .sleepover-delete-button {
+  min-height: 30px;
+  padding: 5px 12px;
+  border: 1px solid rgba(239, 68, 68, 0.45);
+  border-radius: 8px;
+  background: #ffffff;
+  color: #ef4444;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease,
+    opacity 0.15s ease;
 }
 
+.sleepover-page .sleepover-delete-button:hover:not(:disabled) {
+  border-color: #ef4444;
+  background: #ef4444;
+  color: #ffffff;
+}
+
+.sleepover-page .sleepover-delete-button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+/* ===== 외박자 추가 모달 ===== */
+/* 반응형 */
 @media (max-width: 1200px) {
   .sleepover-page .sleepover-primary-button,
   .sleepover-page .sleepover-secondary-button {
@@ -169,12 +131,7 @@
 }
 
 @media (max-width: 768px) {
-  .sleepover-reason-cell {
+  .sleepover-page .sleepover-reason-cell {
     max-width: none;
-  }
-
-  .sleepover-student-option {
-    align-items: flex-start;
-    flex-direction: column;
   }
 }


### PR DESCRIPTION
## Closes #72
Closes #73
Closes #74
Closes #75

## 변경사항

- 인원 확인(#72)/심야자습 확인(#73)/휴대폰 제출 확인(#74)/외박 확인(#75) 4개 페이지의 날짜 선택기·검색 바·통계 박스·상태/성별/학년 필터 버튼을 대시보드 토큰으로 통일
- 학생 테이블: 행 높이·구분선 정리, 상태 셀렉트와 제출 뱃지(O/X/외박/-)를 알파 배경 pill로 칩화, 지연출석/외박 고정 표시 정리
- 외부 동기화 버튼(ghost)과 동기화 결과/에러 배너, 엑셀 내보내기 드롭다운, 점호 회차 이동 컨트롤 개선
- 모든 선택자를 `.check-page`/`.sleepover-page` 페이지 루트로 스코핑해 전역 선택자 충돌 방지

## 스크린샷/동영상

(추후 첨부 예정)

## 참고 사항

- Check.css/Sleepover.css를 4개 페이지가 공유하므로 하나의 PR로 묶었습니다 (파일 단위 분리 불가)
- `design/#78-방관리-제출함-디자인` PR 위에 쌓인 스택 PR입니다 (모달 공용 스타일 의존). #78 PR 머지 후 base를 main으로 재지정 필요 없이 순차 머지 권장
- 기능·API 로직 변경 없음. `npm run lint`, `npm run build` 통과
