### PR TITLE
design :: #76 공지사항 페이지 디자인 변경

### DIFF
--- a/src/styles/Notice.css
+++ b/src/styles/Notice.css
@@ -6,364 +6,313 @@
   color: #0f0f10;
 }
 
-.notice-page-header,
-.notice-toolbar,
-.selection-action-bar,
-.notice-card {
-  border: 1px solid #e6e6e7;
-  border-radius: 12px;
-  background: #ffffff;
-  box-shadow: 0 4px 16px rgba(15, 15, 16, 0.04);
+.notice-page > .notice-page-header,
+.notice-page > .notice-toolbar,
+.notice-page > .notice-list-header,
+.notice-page > .notice-grid {
+  width: min(1180px, 100%);
+  margin-left: auto;
+  margin-right: auto;
 }
 
-.notice-page-header {
+.notice-page .notice-page-header {
   display: flex;
-  align-items: center;
+  align-items: flex-end;
   justify-content: space-between;
   gap: 24px;
-  margin-bottom: 16px;
-  padding: 28px 30px;
-  background:
-    linear-gradient(90deg, rgba(109, 35, 237, 0.1), rgba(109, 35, 237, 0) 46%),
-    #ffffff;
+  margin-bottom: 32px;
 }
 
-.notice-kicker {
+.notice-page .notice-kicker {
+  display: block;
   color: #6d23ed;
-  font-size: 13px;
-  font-weight: 800;
-  letter-spacing: 0;
+  font-size: 12px;
+  font-weight: 700;
 }
 
-.page-title {
+.notice-page .page-title {
   margin: 6px 0 8px;
   color: #0f0f10;
-  font-size: 30px;
+  font-size: 26px;
   font-weight: 800;
-  line-height: 1.2;
-  letter-spacing: 0;
+  line-height: 1.25;
+  letter-spacing: -0.3px;
 }
 
-.notice-page-description {
-  color: #5d5f60;
-  font-size: 15px;
+.notice-page .notice-page-description {
+  margin: 0;
+  color: #747678;
+  font-size: 14px;
   font-weight: 500;
   line-height: 1.55;
 }
 
-.create-button,
-.select-all-button,
-.action-button {
-  min-height: 40px;
-  border-radius: 8px;
-  font-size: 14px;
-  font-weight: 700;
-  cursor: pointer;
-  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
-}
-
-.create-button {
+.notice-page .create-button {
   flex-shrink: 0;
+  min-height: 40px;
   border: 1px solid #6d23ed;
+  border-radius: 8px;
   background: #6d23ed;
   color: #ffffff;
   padding: 0 18px;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease;
 }
 
-.create-button:hover {
+.notice-page .create-button:hover:not(:disabled) {
   border-color: #5919c7;
   background: #5919c7;
-  box-shadow: 0 6px 16px rgba(109, 35, 237, 0.18);
 }
 
-.notice-toolbar {
+.notice-page .notice-toolbar {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  margin-bottom: 16px;
-  padding: 14px 16px;
+  flex-wrap: wrap;
+  gap: 12px 16px;
+  margin-bottom: 32px;
 }
 
 .notice-page .filter-section {
   min-width: 0;
   display: flex;
   align-items: center;
-  align-self: center;
-  flex: 1 1 360px;
-  gap: 6px;
   flex-wrap: wrap;
-  margin: 0;
+  gap: 6px;
 }
 
-.filter-button {
+.notice-page .filter-button {
   min-height: 34px;
-  border: 1px solid #e6e6e7;
+  border: 1px solid #e4e4e7;
   border-radius: 8px;
   background: #ffffff;
-  color: #5d5f60;
-  padding: 0 12px;
+  color: #52525b;
+  padding: 0 14px;
   font-size: 13px;
-  font-weight: 700;
+  font-weight: 600;
   cursor: pointer;
-  transition: all 0.2s;
   white-space: nowrap;
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
 }
 
-.filter-button:hover {
-  border-color: #6d23ed;
+.notice-page .filter-button:hover {
+  background: #f4f4f5;
+}
+
+.notice-page .filter-button.active {
+  border-color: #ede9fe;
+  background: #ede9fe;
   color: #6d23ed;
-  background: rgba(109, 35, 237, 0.05);
 }
 
-.filter-button.active {
-  border-color: #6d23ed;
-  background: #6d23ed;
-  color: #ffffff;
-}
-
-.notice-summary {
+.notice-page .notice-summary {
   display: flex;
   align-items: center;
-  gap: 8px;
-  flex: 0 0 auto;
   flex-wrap: wrap;
-  color: #5d5f60;
-  font-size: 13px;
-  font-weight: 700;
-}
-
-.notice-summary span {
-  min-height: 32px;
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  border-radius: 999px;
-  background: #f5f5f5;
-  padding: 0 12px;
-}
-
-.notice-summary strong {
-  color: #6d23ed;
-}
-
-.selection-action-bar {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 18px;
-  margin-bottom: 16px;
-  padding: 16px 18px;
-  border-color: rgba(109, 35, 237, 0.24);
-  background: #fbf9ff;
-}
-
-.selection-copy {
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
-}
-
-.selection-copy strong {
-  color: #0f0f10;
-  font-size: 15px;
-  font-weight: 800;
-}
-
-.selection-copy span {
+  gap: 6px;
+  flex: 0 0 auto;
   color: #747678;
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 600;
 }
 
-.selection-actions {
-  display: flex;
+.notice-page .notice-summary span {
+  min-height: 28px;
+  display: inline-flex;
   align-items: center;
-  gap: 8px;
-  flex-wrap: wrap;
-  justify-content: flex-end;
+  gap: 5px;
+  border-radius: 999px;
+  background: #f4f4f5;
+  padding: 0 11px;
 }
 
-.action-button,
-.select-all-button {
-  border: 1px solid #e6e6e7;
-  background: #ffffff;
-  color: #5d5f60;
-  padding: 0 14px;
+.notice-page .notice-summary strong {
+  color: #0f0f10;
+  font-weight: 700;
 }
 
-.action-button:hover:not(:disabled),
-.select-all-button:hover {
-  border-color: #6d23ed;
-  color: #6d23ed;
-  background: rgba(109, 35, 237, 0.05);
-}
-
-.action-button.pin {
-  border-color: #6d23ed;
-  background: #6d23ed;
-  color: #ffffff;
-}
-
-.action-button.pin:hover:not(:disabled) {
-  border-color: #5919c7;
-  background: #5919c7;
-  color: #ffffff;
-}
-
-.action-button.unpin {
-  border-color: rgba(109, 35, 237, 0.45);
-  background: rgba(109, 35, 237, 0.08);
-  color: #6d23ed;
-}
-
-.action-button.unpin:hover:not(:disabled) {
-  border-color: #6d23ed;
-  background: #6d23ed;
-  color: #ffffff;
-}
-
-.action-button.delete {
-  border-color: rgba(255, 66, 66, 0.34);
-  color: #ff4242;
-}
-
-.action-button.delete:hover:not(:disabled) {
-  border-color: #ff4242;
-  background: #ff4242;
-  color: #ffffff;
-}
-
-.action-button:disabled,
-.select-all-button:disabled {
-  opacity: 0.55;
-  cursor: not-allowed;
-}
-
-.notice-list-header {
+.notice-page .notice-list-header {
   display: flex;
   align-items: flex-end;
   justify-content: space-between;
   gap: 16px;
-  margin: 22px 0 12px;
+  margin-bottom: 14px;
 }
 
-.notice-list-actions {
+.notice-page .notice-list-header h2 {
+  margin: 3px 0 0;
+  color: #0f0f10;
+  font-size: 17px;
+  font-weight: 700;
+  letter-spacing: -0.3px;
+}
+
+.notice-page .notice-list-actions {
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 8px;
   flex-wrap: wrap;
+  gap: 8px;
 }
 
-.notice-list-actions .select-all-button,
-.notice-list-actions .action-button {
-  width: auto;
-  min-width: 88px;
+.notice-page .select-all-button,
+.notice-page .action-button {
+  min-height: 34px;
+  min-width: 84px;
+  border-radius: 8px;
   padding: 0 14px;
-  border: 1px solid #e6e6e7;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
 }
 
-.notice-list-header h2 {
-  margin: 3px 0 0;
-  color: #0f0f10;
-  font-size: 22px;
-  font-weight: 800;
-  line-height: 1.25;
+.notice-page .select-all-button {
+  border: none;
+  background: transparent;
+  color: #747678;
 }
 
-.notice-grid {
+.notice-page .select-all-button:hover:not(:disabled) {
+  background: #f4f4f5;
+}
+
+.notice-page .action-button {
+  border: 1px solid #e4e4e7;
+  background: #ffffff;
+  color: #52525b;
+}
+
+.notice-page .action-button:hover:not(:disabled) {
+  background: #f4f4f5;
+}
+
+.notice-page .action-button.pin {
+  border-color: rgba(109, 35, 237, 0.24);
+  background: #ede9fe;
+  color: #6d23ed;
+}
+
+.notice-page .action-button.pin:hover:not(:disabled) {
+  border-color: rgba(109, 35, 237, 0.36);
+  background: rgba(109, 35, 237, 0.14);
+  color: #6d23ed;
+}
+
+.notice-page .action-button.unpin:hover:not(:disabled) {
+  border-color: #c9c9cc;
+}
+
+.notice-page .action-button.delete {
+  border-color: rgba(239, 68, 68, 0.32);
+  color: #ef4444;
+}
+
+.notice-page .action-button.delete:hover:not(:disabled) {
+  border-color: #ef4444;
+  background: rgba(239, 68, 68, 0.06);
+  color: #ef4444;
+}
+
+.notice-page .action-button:disabled,
+.notice-page .select-all-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.notice-page .notice-grid {
   display: grid;
   grid-template-columns: minmax(0, 1fr);
-  gap: 14px;
+  gap: 12px;
 }
 
-.notice-card {
-  min-height: 174px;
+.notice-page .notice-card {
+  position: relative;
   display: flex;
   flex-direction: column;
-  gap: 16px;
-  padding: 18px;
+  gap: 14px;
+  padding: 18px 20px;
+  border: 1px solid #e5e5e5;
+  border-radius: 12px;
+  background: #ffffff;
   cursor: pointer;
-  position: relative;
-  transition: border-color 0.18s ease, box-shadow 0.18s ease, transform 0.18s ease, background 0.18s ease;
+  transition: border-color 0.15s ease, background-color 0.15s ease;
 }
 
-.notice-card:hover {
-  transform: translateY(-1px);
-  border-color: rgba(109, 35, 237, 0.36);
-  box-shadow: 0 8px 24px rgba(109, 35, 237, 0.1);
+.notice-page .notice-card:hover {
+  border-color: #c9c9cc;
 }
 
-.notice-card.selected {
+.notice-page .notice-card.selected {
   border-color: #6d23ed;
-  background: #fbf9ff;
-  box-shadow: 0 8px 24px rgba(109, 35, 237, 0.14);
+  background: rgba(109, 35, 237, 0.04);
 }
 
-.notice-card.pinned {
-  border-top-color: rgba(109, 35, 237, 0.5);
+.notice-page .notice-card.pinned {
+  border-top-color: rgba(109, 35, 237, 0.45);
 }
 
-.notice-header,
-.notice-card-footer {
+.notice-page .notice-header,
+.notice-page .notice-card-footer {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
   gap: 12px;
 }
 
-.notice-badges {
+.notice-page .notice-badges {
   display: flex;
   align-items: center;
-  gap: 6px;
   flex-wrap: wrap;
+  gap: 6px;
 }
 
-.notice-pin-badge,
-.notice-category {
-  min-height: 24px;
+.notice-page .notice-pin-badge,
+.notice-page .notice-category {
+  min-height: 22px;
   display: inline-flex;
   align-items: center;
   gap: 4px;
   border-radius: 999px;
-  padding: 0 9px;
+  padding: 0 8px;
   font-size: 12px;
-  font-weight: 800;
+  font-weight: 600;
 }
 
-.notice-pin-badge {
-  background: #6d23ed;
-  color: #ffffff;
-  box-shadow: 0 6px 14px rgba(109, 35, 237, 0.18);
+.notice-page .notice-pin-badge {
+  background: rgba(109, 35, 237, 0.08);
+  color: #6d23ed;
+  font-weight: 700;
 }
 
-.notice-pin-badge-icon {
-  width: 13px;
-  height: 13px;
+.notice-page .notice-pin-badge-icon {
+  width: 12px;
+  height: 12px;
   flex-shrink: 0;
 }
 
-.notice-category {
-  background: #f5f5f5;
+.notice-page .notice-category {
+  background: #f4f4f5;
   color: #747678;
 }
 
-.notice-select {
+.notice-page .notice-select {
   width: 28px;
   height: 28px;
   display: grid;
   place-items: center;
   border-radius: 8px;
   cursor: pointer;
-  transition: background 0.2s ease;
+  transition: background-color 0.15s ease;
 }
 
-.notice-select:hover {
+.notice-page .notice-select:hover {
   background: rgba(109, 35, 237, 0.08);
 }
 
-.notice-checkbox {
+.notice-page .notice-checkbox {
   width: 16px;
   height: 16px;
   margin: 0;
@@ -371,63 +320,69 @@
   accent-color: #6d23ed;
 }
 
-.notice-title {
+.notice-page .notice-title {
   display: -webkit-box;
   margin: 0;
   overflow: hidden;
   color: #0f0f10;
-  font-size: 18px;
-  font-weight: 800;
-  line-height: 1.45;
+  font-size: 15px;
+  font-weight: 700;
+  line-height: 1.5;
+  letter-spacing: -0.2px;
   text-overflow: ellipsis;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
 }
 
-.notice-card-footer {
+.notice-page .notice-card-footer {
   margin-top: auto;
   align-items: flex-end;
   color: #747678;
-  font-size: 13px;
-  font-weight: 700;
+  font-size: 12px;
+  font-weight: 600;
 }
 
-.notice-author {
+.notice-page .notice-author {
   margin: 0;
-  color: #5d5f60;
+  color: #52525b;
+  font-size: 12px;
+  font-weight: 600;
 }
 
-.notice-date {
+.notice-page .notice-date {
   display: flex;
   flex-direction: column;
   align-items: flex-end;
   gap: 2px;
   margin: 0;
   color: #747678;
+  font-size: 12px;
+  font-weight: 600;
   white-space: nowrap;
 }
 
-.notice-date small {
-  color: #9e9e9f;
-  font-size: 12px;
+.notice-page .notice-date small {
+  color: #a1a1aa;
+  font-size: 11px;
   font-weight: 600;
 }
 
-.notice-empty-state {
+.notice-page .notice-empty-state {
   grid-column: 1 / -1;
-  min-height: 220px;
+  min-height: 200px;
   display: grid;
   place-items: center;
   border: 1px dashed #d8d2e7;
-  border-radius: 12px;
+  border-radius: 10px;
   background: #ffffff;
+  padding: 20px;
   color: #747678;
-  font-size: 14px;
-  font-weight: 700;
+  font-size: 13px;
+  font-weight: 600;
   text-align: center;
 }
 
-.sr-only {
+.notice-page .sr-only {
   position: absolute;
   width: 1px;
   height: 1px;
@@ -444,7 +399,7 @@
     padding: 28px 24px;
   }
 
-  .notice-toolbar {
+  .notice-page .notice-toolbar {
     align-items: stretch;
     flex-direction: column;
   }
@@ -453,34 +408,22 @@
     width: 100%;
     display: grid;
     grid-template-columns: repeat(5, minmax(0, 1fr));
-    flex: none;
     gap: 8px;
   }
 
-  .filter-button {
+  .notice-page .filter-button {
     width: 100%;
     min-height: 38px;
     padding: 0 10px;
   }
 
-  .selection-action-bar {
-    align-items: flex-start;
-    flex-direction: column;
-  }
-
-  .selection-actions {
-    width: 100%;
-    justify-content: flex-start;
-  }
-
-  .notice-summary {
+  .notice-page .notice-summary {
     width: 100%;
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
-    margin-left: auto;
   }
 
-  .notice-summary span {
+  .notice-page .notice-summary span {
     justify-content: center;
   }
 }
@@ -490,34 +433,28 @@
     padding: 22px 18px;
   }
 
-  .notice-page-header {
+  .notice-page .notice-page-header {
     align-items: stretch;
     flex-direction: column;
-    padding: 24px;
   }
 
-  .create-button {
+  .notice-page .create-button {
     width: 100%;
   }
 
-  .page-title {
-    font-size: 26px;
-  }
-
-  .notice-list-header {
+  .notice-page .notice-list-header {
     align-items: stretch;
     flex-direction: column;
   }
 
-  .notice-list-actions {
+  .notice-page .notice-list-actions {
     width: 100%;
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(96px, 1fr));
   }
 
-  .notice-list-actions .select-all-button,
-  .notice-list-actions .action-button,
-  .select-all-button {
+  .notice-page .notice-list-actions .select-all-button,
+  .notice-page .notice-list-actions .action-button {
     width: 100%;
   }
 }
@@ -527,15 +464,8 @@
     padding: 18px 14px;
   }
 
-  .notice-page-header,
-  .notice-toolbar,
-  .selection-action-bar {
-    padding: 18px;
-  }
-
-  .notice-toolbar {
-    gap: 12px;
-    padding: 14px;
+  .notice-page .page-title {
+    font-size: 22px;
   }
 
   .notice-page .filter-section {
@@ -547,42 +477,34 @@
     grid-column: 1 / -1;
   }
 
-  .filter-button {
+  .notice-page .filter-button {
     min-height: 40px;
     padding: 0 10px;
   }
 
-  .notice-summary {
-    margin-left: 0;
+  .notice-page .notice-summary {
     gap: 6px;
   }
 
-  .notice-summary span {
+  .notice-page .notice-summary span {
     justify-content: center;
     padding: 0 8px;
   }
 
-  .selection-actions {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 8px;
-  }
-
-  .action-button {
-    width: 100%;
-    padding: 0 10px;
-  }
-
-  .notice-grid {
+  .notice-page .notice-grid {
     grid-template-columns: 1fr;
   }
 
-  .notice-card-footer {
+  .notice-page .notice-card {
+    padding: 16px;
+  }
+
+  .notice-page .notice-card-footer {
     align-items: flex-start;
     flex-direction: column;
   }
 
-  .notice-date {
+  .notice-page .notice-date {
     align-items: flex-start;
   }
 }

--- a/src/styles/Notice.css
+++ b/src/styles/Notice.css
@@ -9,7 +9,8 @@
 .notice-page > .notice-page-header,
 .notice-page > .notice-toolbar,
 .notice-page > .notice-list-header,
-.notice-page > .notice-grid {
+.notice-page > .notice-grid,
+.notice-page > .notice-skeleton {
   width: min(1180px, 100%);
   margin-left: auto;
   margin-right: auto;

--- a/src/styles/NoticeCreateModal.css
+++ b/src/styles/NoticeCreateModal.css
@@ -6,7 +6,7 @@
   align-items: center;
   justify-content: center;
   padding: 24px;
-  background: rgba(15, 15, 16, 0.42);
+  background: rgba(15, 15, 16, 0.4);
 }
 
 .notice-modal-backdrop .notice-modal-container {
@@ -16,8 +16,8 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  border: 1px solid #e6e6e7;
-  border-radius: 12px;
+  border: 1px solid #e5e5e5;
+  border-radius: 16px;
   background: #ffffff;
   box-shadow: 0 18px 54px rgba(15, 15, 16, 0.18);
 }
@@ -28,39 +28,37 @@
   justify-content: space-between;
   gap: 16px;
   padding: 22px 24px;
-  border-bottom: 1px solid #e6e6e7;
-  background:
-    linear-gradient(90deg, rgba(109, 35, 237, 0.08), rgba(109, 35, 237, 0) 48%),
-    #ffffff;
+  border-bottom: 1px solid #ececef;
+  background: #ffffff;
 }
 
 .notice-modal-backdrop .modal-title {
   margin: 0;
   color: #0f0f10;
-  font-size: 22px;
+  font-size: 20px;
   font-weight: 800;
   line-height: 1.25;
-  letter-spacing: 0;
+  letter-spacing: -0.3px;
 }
 
 .notice-modal-backdrop .modal-close-button {
   width: 36px;
   height: 36px;
   flex-shrink: 0;
-  border: 1px solid #e6e6e7;
+  border: 1px solid #e4e4e7;
   border-radius: 8px;
   background: #ffffff;
-  color: #5d5f60;
+  color: #52525b;
   font-size: 18px;
-  font-weight: 800;
+  font-weight: 700;
+  line-height: 1;
   cursor: pointer;
-  transition: all 0.2s;
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
 }
 
 .notice-modal-backdrop .modal-close-button:hover:not(:disabled) {
-  border-color: #6d23ed;
-  color: #6d23ed;
-  background: rgba(109, 35, 237, 0.05);
+  border-color: #c9c9cc;
+  background: #f4f4f5;
 }
 
 .notice-modal-backdrop .modal-close-button:disabled {
@@ -72,7 +70,7 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 18px;
+  gap: 20px;
   overflow-y: auto;
   padding: 24px;
   scrollbar-gutter: stable;
@@ -85,39 +83,39 @@
 }
 
 .notice-modal-backdrop .form-label {
-  color: #0f0f10;
+  color: #3f3f46;
   font-size: 14px;
-  font-weight: 800;
+  font-weight: 700;
 }
 
 .notice-modal-backdrop .required {
-  color: #ff4242;
+  color: #ef4444;
 }
 
 .notice-modal-backdrop .form-input,
 .notice-modal-backdrop .form-textarea,
 .notice-modal-backdrop .markdown-preview {
   width: 100%;
-  border: 1px solid #e6e6e7;
-  border-radius: 12px;
+  border: 1px solid #e5e5e5;
+  border-radius: 10px;
   background: #ffffff;
   color: #0f0f10;
   font-family: 'Pretendard', -apple-system, BlinkMacSystemFont, system-ui, Roboto, sans-serif;
   font-size: 14px;
   font-weight: 500;
   outline: none;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
 .notice-modal-backdrop .form-input {
-  height: 48px;
-  padding: 0 16px;
+  height: 44px;
+  padding: 0 14px;
 }
 
 .notice-modal-backdrop .form-textarea,
 .notice-modal-backdrop .markdown-preview {
   min-height: 280px;
-  padding: 16px;
+  padding: 14px 16px;
   overflow-y: auto;
   line-height: 1.65;
   resize: vertical;
@@ -132,84 +130,84 @@
 
 .notice-modal-backdrop .form-input::placeholder,
 .notice-modal-backdrop .form-textarea::placeholder {
-  color: #9e9e9f;
+  color: #a1a1aa;
 }
 
-.content-header {
+.notice-modal-backdrop .content-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 16px;
 }
 
-.editor-controls {
+.notice-modal-backdrop .editor-controls {
   display: flex;
   align-items: center;
-  gap: 10px;
   flex-wrap: wrap;
   justify-content: flex-end;
+  gap: 8px;
 }
 
-.refine-button {
-  min-height: 36px;
+.notice-modal-backdrop .refine-button {
+  min-height: 34px;
   border: 1px solid #6d23ed;
   border-radius: 8px;
   background: #6d23ed;
   color: #ffffff;
   padding: 0 14px;
   font-size: 13px;
-  font-weight: 800;
+  font-weight: 600;
   cursor: pointer;
-  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
   white-space: nowrap;
+  transition: background-color 0.15s ease, border-color 0.15s ease;
 }
 
-.refine-button:hover:not(:disabled) {
+.notice-modal-backdrop .refine-button:hover:not(:disabled) {
   border-color: #5919c7;
   background: #5919c7;
-  box-shadow: 0 6px 16px rgba(109, 35, 237, 0.18);
 }
 
-.refine-button:disabled {
-  border-color: #e6e6e7;
-  background: #eff0f1;
-  color: #9e9e9f;
+.notice-modal-backdrop .refine-button:disabled {
+  border-color: #e4e4e7;
+  background: #f4f4f5;
+  color: #a1a1aa;
   cursor: not-allowed;
 }
 
-.editor-tabs {
+.notice-modal-backdrop .editor-tabs {
   display: flex;
   gap: 4px;
-  border: 1px solid #e6e6e7;
+  border: 1px solid #e4e4e7;
   border-radius: 8px;
-  background: #f5f5f5;
+  background: #f4f4f5;
   padding: 3px;
 }
 
-.tab-button {
+.notice-modal-backdrop .tab-button {
   min-height: 30px;
-  border: 0;
+  border: 1px solid transparent;
   border-radius: 6px;
   background: transparent;
-  color: #5d5f60;
+  color: #52525b;
   padding: 0 12px;
   font-size: 13px;
-  font-weight: 800;
+  font-weight: 600;
   cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease;
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
 }
 
-.tab-button:hover {
-  color: #6d23ed;
-}
-
-.tab-button.active {
+.notice-modal-backdrop .tab-button:hover:not(.active) {
   background: #ffffff;
   color: #6d23ed;
-  box-shadow: 0 1px 3px rgba(15, 15, 16, 0.08);
 }
 
-.input-footer {
+.notice-modal-backdrop .tab-button.active {
+  border-color: #e4e4e7;
+  background: #ffffff;
+  color: #6d23ed;
+}
+
+.notice-modal-backdrop .input-footer {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -217,68 +215,68 @@
   min-height: 18px;
 }
 
-.char-count {
+.notice-modal-backdrop .char-count {
   margin-left: auto;
-  color: #9e9e9f;
+  color: #a1a1aa;
   font-size: 12px;
-  font-weight: 700;
+  font-weight: 600;
   white-space: nowrap;
 }
 
-.error-text {
-  color: #ff4242;
+.notice-modal-backdrop .error-text {
+  color: #ef4444;
   font-size: 12px;
-  font-weight: 700;
+  font-weight: 600;
 }
 
-.markdown-preview {
+.notice-modal-backdrop .markdown-preview {
   color: #0f0f10;
 }
 
-.markdown-preview h1 {
+.notice-modal-backdrop .markdown-preview h1 {
   font-size: 24px;
   font-weight: 800;
   margin: 16px 0 12px;
-  border-bottom: 1px solid #e6e6e7;
+  border-bottom: 1px solid #ececef;
   padding-bottom: 8px;
 }
 
-.markdown-preview h2 {
+.notice-modal-backdrop .markdown-preview h2 {
   font-size: 20px;
   font-weight: 800;
   margin: 14px 0 10px;
-  border-bottom: 1px solid #e6e6e7;
+  border-bottom: 1px solid #ececef;
   padding-bottom: 6px;
 }
 
-.markdown-preview h3 {
+.notice-modal-backdrop .markdown-preview h3 {
   font-size: 18px;
   font-weight: 700;
   margin: 12px 0 8px;
 }
 
-.markdown-preview p {
+.notice-modal-backdrop .markdown-preview p {
   margin: 8px 0;
 }
 
-.markdown-preview ul,
-.markdown-preview ol {
+.notice-modal-backdrop .markdown-preview ul,
+.notice-modal-backdrop .markdown-preview ol {
   margin: 8px 0;
   padding-left: 24px;
 }
 
-.markdown-preview li {
+.notice-modal-backdrop .markdown-preview li {
   margin: 4px 0;
 }
 
-.markdown-preview a {
+.notice-modal-backdrop .markdown-preview a {
   color: #6d23ed;
   text-decoration: none;
   border-bottom: 1px solid rgba(109, 35, 237, 0.3);
 }
 
-.markdown-preview code {
-  background: #f5f5f5;
+.notice-modal-backdrop .markdown-preview code {
+  background: #f4f4f5;
   padding: 2px 6px;
   border-radius: 4px;
   color: #d63384;
@@ -286,57 +284,58 @@
   font-size: 13px;
 }
 
-.markdown-preview pre {
+.notice-modal-backdrop .markdown-preview pre {
   overflow-x: auto;
   margin: 12px 0;
   border-radius: 8px;
-  background: #f5f5f5;
+  background: #f4f4f5;
   padding: 12px;
 }
 
-.markdown-preview pre code {
+.notice-modal-backdrop .markdown-preview pre code {
   background: transparent;
   color: #0f0f10;
   padding: 0;
 }
 
-.markdown-preview blockquote {
+.notice-modal-backdrop .markdown-preview blockquote {
   margin: 12px 0;
   border-left: 4px solid #6d23ed;
-  color: #5d5f60;
+  color: #52525b;
   padding-left: 16px;
 }
 
-.markdown-preview table {
+.notice-modal-backdrop .markdown-preview table {
   width: 100%;
   margin: 12px 0;
   border-collapse: collapse;
 }
 
-.markdown-preview table th,
-.markdown-preview table td {
-  border: 1px solid #e6e6e7;
+.notice-modal-backdrop .markdown-preview table th,
+.notice-modal-backdrop .markdown-preview table td {
+  border: 1px solid #e5e5e5;
   padding: 8px 12px;
   text-align: left;
 }
 
-.markdown-preview table th {
-  background: #f5f5f5;
+.notice-modal-backdrop .markdown-preview table th {
+  background: #f4f4f5;
   font-weight: 700;
 }
 
-.markdown-preview img {
+.notice-modal-backdrop .markdown-preview img {
   max-width: 100%;
   margin: 12px 0;
   border-radius: 8px;
 }
 
-.preview-empty {
+.notice-modal-backdrop .preview-empty {
   display: grid;
   min-height: 220px;
   place-items: center;
-  color: #9e9e9f;
-  font-weight: 700;
+  color: #747678;
+  font-size: 13px;
+  font-weight: 600;
 }
 
 .notice-modal-backdrop .modal-actions {
@@ -344,31 +343,29 @@
   justify-content: flex-end;
   gap: 10px;
   margin-top: 4px;
-  padding-top: 20px;
-  border-top: 1px solid #e6e6e7;
+  padding-top: 18px;
+  border-top: 1px solid #ececef;
 }
 
 .notice-modal-backdrop .cancel-button,
 .notice-modal-backdrop .submit-button {
-  min-height: 44px;
+  min-height: 42px;
   border-radius: 8px;
   padding: 0 22px;
   font-size: 14px;
-  font-weight: 800;
+  font-weight: 700;
   cursor: pointer;
-  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
 }
 
 .notice-modal-backdrop .cancel-button {
-  border: 1px solid #e6e6e7;
+  border: 1px solid #e4e4e7;
   background: #ffffff;
-  color: #5d5f60;
+  color: #52525b;
 }
 
 .notice-modal-backdrop .cancel-button:hover:not(:disabled) {
-  border-color: #6d23ed;
-  color: #6d23ed;
-  background: rgba(109, 35, 237, 0.05);
+  background: #f4f4f5;
 }
 
 .notice-modal-backdrop .submit-button {
@@ -380,7 +377,6 @@
 .notice-modal-backdrop .submit-button:hover:not(:disabled) {
   border-color: #5919c7;
   background: #5919c7;
-  box-shadow: 0 6px 16px rgba(109, 35, 237, 0.18);
 }
 
 .notice-modal-backdrop .cancel-button:disabled,
@@ -404,12 +400,12 @@
     padding: 20px;
   }
 
-  .content-header {
+  .notice-modal-backdrop .content-header {
     align-items: stretch;
     flex-direction: column;
   }
 
-  .editor-controls {
+  .notice-modal-backdrop .editor-controls {
     justify-content: flex-start;
   }
 
@@ -434,17 +430,17 @@
     border-radius: 0;
   }
 
-  .editor-controls {
+  .notice-modal-backdrop .editor-controls {
     display: grid;
     grid-template-columns: 1fr;
   }
 
-  .editor-tabs,
-  .refine-button {
+  .notice-modal-backdrop .editor-tabs,
+  .notice-modal-backdrop .refine-button {
     width: 100%;
   }
 
-  .tab-button {
+  .notice-modal-backdrop .tab-button {
     flex: 1;
   }
 }


### PR DESCRIPTION
## Closes #76

## 변경사항

- 페이지 헤더를 그라데이션 카드에서 대시보드형 플레인 헤더(26px/800 + 설명문)로 변경, 콘텐츠 최대폭 1180px 중앙정렬
- 기간 필터 탭과 요약 카운트(전체/고정/표시)를 토큰형 버튼(#e4e4e7 보더, 선택 시 #ede9fe+#6d23ed)으로 정리
- 공지 카드 그림자 제거 후 보더 중심(hover #c9c9cc)으로 정리, 선택 상태는 #6d23ed 보더 + 틴트 배경, 고정 핀·카테고리 뱃지 개선
- 목록 액션 버튼(전체 선택=ghost, 고정=보라 틴트, 삭제=위험 톤)과 공지 작성 모달(ConfirmationModal 패턴) 정리
- 모든 선택자를 `.notice-page` 등 페이지 루트로 스코핑해 대시보드·다른 페이지로의 전역 스타일 누수 차단

## 스크린샷/동영상

(추후 첨부 예정)

## 참고 사항

- 기능·API 로직 변경 없음. `npm run lint`, `npm run build` 통과
- 기존 Notice.css의 전역 규칙 제거로 미라우팅 레거시 페이지(notice/create)에는 영향 가능하나 라우팅되지 않는 페이지라 확인 결과 문제 없음
