### PR TITLE
design :: #80 패치노트 페이지 디자인 변경

### DIFF
--- a/src/styles/PatchNote.css
+++ b/src/styles/PatchNote.css
@@ -1,4 +1,6 @@
-/* 패치노트 공개 페이지 스타일 - Qvick 디자인 시스템 */
+/* 패치노트 공개 페이지 스타일
+   - 대시보드/사이드바/탑바 톤의 디자인 토큰 적용 (배경 #fafafa, 카드 보더 중심, 그림자 없음)
+   - 모든 선택자는 .patchnote-page 하위로 스코핑하여 다른 페이지와의 충돌 방지 */
 
 .patchnote-page {
   min-height: 100vh;
@@ -7,145 +9,117 @@
   flex-direction: column;
 }
 
-.patchnote-loading {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  min-height: 100vh;
-  gap: 16px;
-}
-
-/* 스켈레톤 로딩 */
-.skeleton {
-  background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%);
+/* 로딩 스켈레톤 (페이지 스코프 내에서만 적용) */
+.patchnote-page .skeleton {
+  background: linear-gradient(90deg, #f1f1f3 25%, #e9e9ec 50%, #f1f1f3 75%);
   background-size: 200% 100%;
-  animation: skeleton-loading 1.5s infinite;
+  animation: pn-skeleton-loading 1.5s infinite ease-in-out;
   border-radius: 4px;
 }
 
-@keyframes skeleton-loading {
-  0% { background-position: 200% 0; }
-  100% { background-position: -200% 0; }
+@keyframes pn-skeleton-loading {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
 }
 
-.article-content-skeleton {
+.patchnote-page .article-content-skeleton {
   padding: 0;
 }
 
-.skeleton-line {
-  height: 16px;
+.patchnote-page .skeleton-line {
+  height: 14px;
   margin-bottom: 12px;
   border-radius: 4px;
 }
 
-.skeleton-line.title {
-  height: 24px;
+.patchnote-page .skeleton-line.title {
+  height: 22px;
   width: 60%;
   margin-bottom: 20px;
 }
 
-.skeleton-line.short {
+.patchnote-page .skeleton-line.short {
   width: 40%;
 }
 
-.skeleton-line.medium {
+.patchnote-page .skeleton-line.medium {
   width: 70%;
 }
 
-.skeleton-line.long {
+.patchnote-page .skeleton-line.long {
   width: 90%;
 }
 
-/* 사이드바 스켈레톤 아이템 */
-.version-item.skeleton-item {
+.patchnote-page .version-item.skeleton-item {
   cursor: default;
   pointer-events: none;
-  padding: 16px;
 }
 
-.version-item.skeleton-item:hover {
+.patchnote-page .version-item.skeleton-item:hover {
   background: transparent;
-  transform: none;
 }
 
-.loading-spinner {
-  width: 40px;
-  height: 40px;
-  border: 3px solid #e6e6e7;
-  border-top-color: #6d23ed;
-  border-radius: 50%;
-  animation: spin 1s linear infinite;
-}
-
-@keyframes spin {
-  to { transform: rotate(360deg); }
-}
-
-.patchnote-loading p {
-  font-size: 14px;
-  color: #747678;
-}
-
-/* 헤더 */
-.patchnote-header {
+/* 헤더 (탑바 톤: 밝은 배경 + 크롬 보더, 은은한 장식) */
+.patchnote-page .patchnote-header {
   position: relative;
-  padding: 60px 24px 80px;
-  background: linear-gradient(135deg, #0f0f10 0%, #1a1a2e 100%);
   overflow: hidden;
+  padding: 48px 24px 44px;
+  background: #ffffff;
+  border-bottom: 1px solid #ececef;
 }
 
-.header-content {
+.patchnote-page .header-content {
   position: relative;
   z-index: 1;
-  max-width: 1200px;
+  max-width: 1180px;
   margin: 0 auto;
   text-align: center;
 }
 
-.header-brand {
+.patchnote-page .header-brand {
   display: inline-flex;
   align-items: center;
-  gap: 12px;
-  margin-bottom: 24px;
-  cursor: pointer;
-  transition: opacity 0.2s;
+  gap: 10px;
+  margin-bottom: 20px;
 }
 
-.header-brand:hover {
-  opacity: 0.8;
+.patchnote-page .qvick-logo {
+  width: 40px;
+  height: 40px;
 }
 
-.qvick-logo {
-  width: 48px;
-  height: 48px;
+.patchnote-page .qvick-logo path:not([fill^='url']) {
+  fill: #0f0f10;
 }
 
-.qvick-logo path:not([fill^="url"]) {
-  fill: #fff;
-}
-
-.brand-text {
-  font-size: 28px;
-  font-weight: 700;
-  color: #fff;
-}
-
-.header-title {
-  font-size: 48px;
+.patchnote-page .brand-text {
+  font-size: 20px;
   font-weight: 800;
-  color: #fff;
-  margin: 0 0 12px;
-  letter-spacing: -0.02em;
+  letter-spacing: -0.3px;
+  color: #0f0f10;
 }
 
-.header-subtitle {
-  font-size: 18px;
-  color: rgba(255, 255, 255, 0.7);
+.patchnote-page .header-title {
+  margin: 0 0 8px;
+  font-size: 26px;
+  font-weight: 800;
+  letter-spacing: -0.3px;
+  color: #0f0f10;
+}
+
+.patchnote-page .header-subtitle {
   margin: 0;
+  font-size: 14px;
+  font-weight: 500;
+  color: #747678;
 }
 
-.header-decoration {
+/* 헤더 장식 (밝은 배경 위 은은한 브랜드 컬러 워시) */
+.patchnote-page .header-decoration {
   position: absolute;
   top: 0;
   left: 0;
@@ -154,496 +128,569 @@
   pointer-events: none;
 }
 
-.decoration-circle {
+.patchnote-page .decoration-circle {
   position: absolute;
   border-radius: 50%;
-  opacity: 0.1;
 }
 
-.circle-1 {
-  width: 400px;
-  height: 400px;
-  background: linear-gradient(135deg, #6d23ed, #1492fc);
-  top: -200px;
-  right: -100px;
+.patchnote-page .circle-1 {
+  width: 420px;
+  height: 420px;
+  top: -260px;
+  right: -120px;
+  background: radial-gradient(closest-side, rgba(109, 35, 237, 0.08), rgba(109, 35, 237, 0));
 }
 
-.circle-2 {
-  width: 300px;
-  height: 300px;
-  background: linear-gradient(135deg, #897eed, #6d23ed);
-  bottom: -150px;
-  left: -50px;
+.patchnote-page .circle-2 {
+  width: 320px;
+  height: 320px;
+  bottom: -200px;
+  left: -80px;
+  background: radial-gradient(closest-side, rgba(137, 126, 237, 0.07), rgba(137, 126, 237, 0));
 }
 
-.circle-3 {
-  width: 200px;
-  height: 200px;
-  background: linear-gradient(135deg, #1492fc, #6d23ed);
+.patchnote-page .circle-3 {
+  width: 240px;
+  height: 240px;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
+  background: radial-gradient(closest-side, rgba(20, 146, 252, 0.05), rgba(20, 146, 252, 0));
 }
 
 /* 컨테이너 */
-.patchnote-container {
+.patchnote-page .patchnote-container {
   flex: 1;
-  max-width: 1200px;
   width: 100%;
-  margin: -40px auto 0;
-  padding: 0 24px 60px;
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 32px 40px 64px;
   position: relative;
   z-index: 1;
 }
 
 /* 빈 상태 */
-.empty-state {
+.patchnote-page .patchnote-container .empty-state {
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 80px 24px;
-  background: #fff;
-  border-radius: 16px;
+  padding: 64px 32px;
+  background: #ffffff;
+  border: 1px dashed #d8d2e7;
+  border-radius: 10px;
   text-align: center;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
 }
 
-.empty-icon {
-  font-size: 64px;
-  margin-bottom: 24px;
+.patchnote-page .empty-icon {
+  font-size: 36px;
+  margin-bottom: 12px;
 }
 
-.empty-state h3 {
-  font-size: 20px;
-  font-weight: 600;
+.patchnote-page .empty-state h3 {
+  margin: 0 0 6px;
+  font-size: 15px;
+  font-weight: 700;
   color: #0f0f10;
-  margin: 0 0 8px;
 }
 
-.empty-state p {
-  font-size: 14px;
-  color: #747678;
+.patchnote-page .empty-state p {
   margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: #747678;
 }
 
 /* 레이아웃 */
-.patchnote-layout {
+.patchnote-page .patchnote-layout {
   display: grid;
-  grid-template-columns: 280px 1fr;
+  grid-template-columns: 280px minmax(0, 1fr);
+  align-items: start;
   gap: 24px;
 }
 
-/* 사이드바 */
-.patchnote-sidebar {
-  background: #fff;
-  border-radius: 16px;
-  padding: 24px;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+/* 버전 목록 사이드바 */
+.patchnote-page .patchnote-sidebar {
+  background: #ffffff;
+  border: 1px solid #e5e5e5;
+  border-radius: 12px;
+  padding: 16px;
   height: fit-content;
   position: sticky;
   top: 24px;
 }
 
-.sidebar-header {
+.patchnote-page .sidebar-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 20px;
-  padding-bottom: 16px;
-  border-bottom: 1px solid #e6e6e7;
+  gap: 8px;
+  margin-bottom: 12px;
+  padding: 2px 4px 12px;
+  border-bottom: 1px solid #ececef;
 }
 
-.sidebar-header h2 {
-  font-size: 16px;
+.patchnote-page .sidebar-header h2 {
+  margin: 0;
+  font-size: 17px;
   font-weight: 700;
   color: #0f0f10;
-  margin: 0;
 }
 
-.version-count {
-  font-size: 13px;
+.patchnote-page .version-count {
+  padding: 3px 9px;
+  background: #f4f4f5;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
   color: #747678;
-  background: #f3f4f6;
-  padding: 4px 10px;
-  border-radius: 12px;
 }
 
-.version-list {
+.patchnote-page .version-list {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 4px;
 }
 
-.version-item {
+.patchnote-page .version-item {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
   gap: 6px;
-  padding: 14px 16px;
-  background: #fafafa;
-  border: 2px solid transparent;
-  border-radius: 12px;
-  cursor: pointer;
-  transition: all 0.2s;
-  text-align: left;
   width: 100%;
+  padding: 11px 12px;
+  border: none;
+  border-radius: 10px;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+  font-family: inherit;
+  box-sizing: border-box;
+  transition: background-color 0.15s ease;
 }
 
-.version-item:hover {
-  background: #f3f4f6;
+.patchnote-page .version-item:hover {
+  background: #f4f4f5;
 }
 
-.version-item.active {
-  background: linear-gradient(135deg, rgba(109, 35, 237, 0.05), rgba(20, 146, 252, 0.05));
-  border-color: #6d23ed;
+.patchnote-page .version-item:focus-visible {
+  outline: 2px solid #6d23ed;
+  outline-offset: 2px;
 }
 
-.version-item-header {
+.patchnote-page .version-item.active {
+  background: #ede9fe;
+}
+
+.patchnote-page .version-item.active .version-number,
+.patchnote-page .version-item.active .version-item-title {
+  color: #6d23ed;
+}
+
+.patchnote-page .version-item.active .version-item-date {
+  color: rgba(109, 35, 237, 0.7);
+}
+
+.patchnote-page .version-item-header {
   display: flex;
   align-items: center;
   gap: 8px;
 }
 
-.version-number {
-  font-size: 14px;
-  font-weight: 700;
+.patchnote-page .version-number {
+  font-size: 12px;
+  font-weight: 800;
   color: #6d23ed;
+  white-space: nowrap;
 }
 
-.category-dot {
+.patchnote-page .category-dot {
   width: 8px;
   height: 8px;
+  flex-shrink: 0;
   border-radius: 50%;
 }
 
-.version-item-title {
-  font-size: 14px;
-  font-weight: 500;
-  color: #0f0f10;
+.patchnote-page .version-item-title {
   margin: 0;
-  line-height: 1.4;
+  font-size: 13px;
+  font-weight: 600;
+  color: #3f3f46;
+  line-height: 1.45;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
 }
 
-.version-item-date {
+.patchnote-page .version-item-date {
   font-size: 12px;
+  font-weight: 600;
   color: #747678;
 }
 
 /* 메인 컨텐츠 */
-.patchnote-main {
-  background: #fff;
-  border-radius: 16px;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+.patchnote-page .patchnote-main {
+  background: #ffffff;
+  border: 1px solid #e5e5e5;
+  border-radius: 12px;
   overflow: hidden;
 }
 
-.no-selection {
+.patchnote-page .patchnote-main .no-selection {
   display: flex;
   align-items: center;
   justify-content: center;
-  min-height: 400px;
+  min-height: 360px;
+  padding: 32px;
+  background: #ffffff;
+  border: 1px dashed #d8d2e7;
+  border-radius: 10px;
+  margin: 16px;
+}
+
+.patchnote-page .no-selection p {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
   color: #747678;
-  font-size: 16px;
 }
 
 /* 아티클 */
-.patchnote-article {
-  padding: 40px;
+.patchnote-page .patchnote-article {
+  padding: 24px;
 }
 
-.article-header {
-  margin-bottom: 32px;
-  padding-bottom: 24px;
-  border-bottom: 1px solid #e6e6e7;
+.patchnote-page .article-header {
+  margin-bottom: 24px;
+  padding-bottom: 20px;
+  border-bottom: 1px solid #ececef;
 }
 
-.article-meta {
+.patchnote-page .article-meta {
   display: flex;
-  align-items: center;
-  gap: 12px;
-  margin-bottom: 16px;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 14px;
 }
 
-.category-badge {
+/* 뱃지 공통 형태 (카테고리 색상은 인라인 토큰 유지) */
+.patchnote-page .category-badge,
+.patchnote-page .version-badge {
   display: inline-flex;
   align-items: center;
-  padding: 6px 14px;
-  border-radius: 8px;
-  font-size: 14px;
-  font-weight: 600;
-}
-
-.version-badge {
-  display: inline-flex;
-  align-items: center;
-  padding: 6px 14px;
-  background: #f3f4f6;
-  border-radius: 8px;
-  font-size: 14px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
   font-weight: 700;
-  color: #374151;
-}
-
-.article-title {
-  font-size: 36px;
-  font-weight: 800;
-  color: #0f0f10;
-  margin: 0 0 16px;
   line-height: 1.3;
-  letter-spacing: -0.02em;
+  white-space: nowrap;
 }
 
-.article-info {
+.patchnote-page .version-badge {
+  color: #52525b;
+  background: #f4f4f5;
+}
+
+.patchnote-page .article-title {
+  margin: 0 0 10px;
+  font-size: 24px;
+  font-weight: 800;
+  letter-spacing: -0.3px;
+  line-height: 1.35;
+  color: #0f0f10;
+}
+
+.patchnote-page .article-info {
   display: flex;
   align-items: center;
-  gap: 16px;
-  font-size: 14px;
+  font-size: 12px;
+  font-weight: 600;
   color: #747678;
 }
 
-.article-date::after {
+.patchnote-page .article-author::before {
   content: '·';
-  margin-left: 16px;
+  margin-right: 12px;
 }
 
-/* 아티클 컨텐츠 */
-.article-content {
-  font-size: 16px;
-  line-height: 1.8;
-  color: #374151;
+/* 마크다운 아티클 타이포그래피 */
+.patchnote-page .patchnote-article .article-content {
+  font-size: 15px;
+  font-weight: 500;
+  line-height: 1.7;
+  color: #3f3f46;
 }
 
-.article-content h1 {
-  font-size: 28px;
-  font-weight: 800;
-  color: #0f0f10;
-  margin: 16px 0 12px;
-  padding-bottom: 12px;
-  border-bottom: 2px solid #e6e6e7;
-}
-
-.article-content h1:first-child {
+.patchnote-page .article-content > :first-child {
   margin-top: 0;
 }
 
-.article-content h2 {
-  font-size: 22px;
+.patchnote-page .article-content > :last-child {
+  margin-bottom: 0;
+}
+
+.patchnote-page .article-content h1 {
+  margin: 28px 0 12px;
+  font-size: 24px;
+  font-weight: 800;
+  letter-spacing: -0.3px;
+  line-height: 1.35;
+  color: #0f0f10;
+}
+
+.patchnote-page .article-content h2 {
+  margin: 28px 0 12px;
+  font-size: 20px;
+  font-weight: 800;
+  letter-spacing: -0.3px;
+  line-height: 1.4;
+  color: #0f0f10;
+}
+
+.patchnote-page .article-content h3 {
+  margin: 20px 0 8px;
+  font-size: 17px;
   font-weight: 700;
   color: #0f0f10;
-  margin: 16px 0 10px;
 }
 
-.article-content h2:first-child {
-  margin-top: 0;
+.patchnote-page .article-content h4,
+.patchnote-page .article-content h5,
+.patchnote-page .article-content h6 {
+  margin: 16px 0 8px;
+  font-size: 15px;
+  font-weight: 700;
+  color: #3f3f46;
 }
 
-.article-content h3 {
-  font-size: 18px;
-  font-weight: 600;
-  color: #374151;
-  margin: 12px 0 8px;
+.patchnote-page .article-content p {
+  margin: 10px 0;
 }
 
-.article-content h3:first-child {
-  margin-top: 0;
+.patchnote-page .article-content ul,
+.patchnote-page .article-content ol {
+  margin: 10px 0;
+  padding-left: 22px;
 }
 
-.article-content p {
-  margin: 12px 0;
+.patchnote-page .article-content ul {
+  list-style-type: disc;
 }
 
-.article-content ul {
-  padding-left: 24px;
-  margin: 8px 0;
-}
-
-.article-content li {
+.patchnote-page .article-content li {
   margin: 4px 0;
-  position: relative;
+  line-height: 1.6;
 }
 
-.article-content li::marker {
+.patchnote-page .article-content li::marker {
   color: #6d23ed;
 }
 
-.article-content code {
-  padding: 3px 8px;
-  background: linear-gradient(135deg, rgba(109, 35, 237, 0.08), rgba(20, 146, 252, 0.08));
-  border-radius: 6px;
-  font-family: 'SF Mono', 'Menlo', 'Monaco', monospace;
-  font-size: 14px;
-  color: #6d23ed;
-}
-
-.article-content strong {
-  font-weight: 600;
+.patchnote-page .article-content strong {
+  font-weight: 700;
   color: #0f0f10;
 }
 
-.article-content a {
-  color: #1492fc;
+.patchnote-page .article-content a {
+  color: #6d23ed;
+  font-weight: 600;
   text-decoration: none;
-  font-weight: 500;
 }
 
-.article-content a:hover {
+.patchnote-page .article-content a:hover {
   text-decoration: underline;
 }
 
-/* 푸터 */
-.patchnote-footer {
-  background: #0f0f10;
-  padding: 40px 24px;
+.patchnote-page .article-content code {
+  padding: 2px 6px;
+  background: #f4f4f5;
+  border-radius: 6px;
+  font-family: 'SF Mono', 'Menlo', 'Monaco', 'Fira Code', monospace;
+  font-size: 13px;
+  color: #6d23ed;
 }
 
-.footer-content {
-  max-width: 1200px;
+.patchnote-page .article-content pre {
+  margin: 12px 0;
+  padding: 12px 16px;
+  background: #f4f4f5;
+  border-radius: 8px;
+  overflow-x: auto;
+}
+
+.patchnote-page .article-content pre code {
+  padding: 0;
+  background: transparent;
+  border-radius: 0;
+  color: #3f3f46;
+}
+
+.patchnote-page .article-content blockquote {
+  margin: 12px 0;
+  padding: 2px 0 2px 14px;
+  border-left: 3px solid #e5e5e5;
+  color: #747678;
+}
+
+.patchnote-page .article-content hr {
+  margin: 20px 0;
+  border: none;
+  border-top: 1px solid #ececef;
+}
+
+.patchnote-page .article-content table {
+  width: 100%;
+  margin: 12px 0;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.patchnote-page .article-content th,
+.patchnote-page .article-content td {
+  padding: 8px 12px;
+  border: 1px solid #ececef;
+  text-align: left;
+}
+
+.patchnote-page .article-content th {
+  background: #fafafa;
+  color: #0f0f10;
+  font-weight: 700;
+}
+
+/* 패치노트 이미지 */
+.patchnote-page .patchnote-image {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  margin: 16px 0;
+  border: 1px solid #ececef;
+  border-radius: 8px;
+}
+
+/* 푸터 (탑바 톤: 밝은 배경 + 크롬 보더) */
+.patchnote-page .patchnote-footer {
+  background: #ffffff;
+  border-top: 1px solid #ececef;
+  padding: 28px 40px;
+}
+
+.patchnote-page .footer-content {
+  max-width: 1180px;
   margin: 0 auto;
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 16px;
 }
 
-.footer-brand {
+.patchnote-page .footer-brand {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
 }
 
-.footer-brand .qvick-logo {
-  width: 32px;
-  height: 32px;
+.patchnote-page .footer-brand .qvick-logo {
+  width: 24px;
+  height: 24px;
 }
 
-.footer-brand span {
-  font-size: 18px;
-  font-weight: 700;
-  color: #fff;
+.patchnote-page .footer-brand span {
+  font-size: 15px;
+  font-weight: 800;
+  letter-spacing: -0.3px;
+  color: #0f0f10;
 }
 
-.footer-copyright {
-  font-size: 14px;
-  color: rgba(255, 255, 255, 0.5);
+.patchnote-page .footer-copyright {
   margin: 0;
+  font-size: 12px;
+  font-weight: 600;
+  color: #747678;
 }
 
 /* 반응형 */
 @media (max-width: 992px) {
-  .patchnote-layout {
+  .patchnote-page .patchnote-layout {
     grid-template-columns: 1fr;
   }
-  
-  .patchnote-sidebar {
+
+  .patchnote-page .patchnote-sidebar {
     position: static;
   }
-  
-  .version-list {
+
+  .patchnote-page .version-list {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-    gap: 12px;
+    gap: 8px;
   }
 }
 
 @media (max-width: 768px) {
-  .patchnote-header {
-    padding: 40px 16px 60px;
+  .patchnote-page .patchnote-header {
+    padding: 36px 16px 36px;
   }
-  
-  .header-title {
-    font-size: 32px;
+
+  .patchnote-page .patchnote-container {
+    padding: 24px 16px 48px;
   }
-  
-  .header-subtitle {
-    font-size: 16px;
+
+  .patchnote-page .patchnote-sidebar {
+    padding: 12px;
   }
-  
-  .patchnote-container {
-    padding: 0 16px 40px;
-    margin-top: -30px;
-  }
-  
-  .patchnote-sidebar {
-    padding: 16px;
-  }
-  
-  .version-list {
+
+  .patchnote-page .version-list {
     grid-template-columns: 1fr;
   }
-  
-  .patchnote-article {
-    padding: 24px;
+
+  .patchnote-page .patchnote-article {
+    padding: 20px;
   }
-  
-  .article-title {
-    font-size: 24px;
+
+  .patchnote-page .article-title {
+    font-size: 22px;
   }
-  
-  .article-info {
+
+  .patchnote-page .article-info {
     flex-direction: column;
     align-items: flex-start;
     gap: 4px;
   }
-  
-  .article-date::after {
+
+  .patchnote-page .article-author::before {
     display: none;
   }
-  
-  .footer-content {
+
+  .patchnote-page .patchnote-footer {
+    padding: 24px 16px;
+  }
+
+  .patchnote-page .footer-content {
     flex-direction: column;
-    gap: 16px;
     text-align: center;
   }
 }
 
 @media (max-width: 480px) {
-  .qvick-logo {
-    width: 36px;
-    height: 36px;
+  .patchnote-page .qvick-logo {
+    width: 32px;
+    height: 32px;
   }
-  
-  .brand-text {
-    font-size: 22px;
+
+  .patchnote-page .brand-text {
+    font-size: 18px;
   }
-  
-  .header-title {
-    font-size: 28px;
+
+  .patchnote-page .header-title {
+    font-size: 24px;
   }
-  
-  .article-meta {
-    flex-wrap: wrap;
+
+  .patchnote-page .patchnote-article {
+    padding: 16px;
   }
-}
 
-/* Visibility 배지 */
-.visibility-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 4px 10px;
-  border-radius: 6px;
-  font-size: 12px;
-  font-weight: 600;
-}
-
-.visibility-badge.teacher {
-  background: #fef3c7;
-  color: #d97706;
-}
-
-/* 패치노트 이미지 */
-.patchnote-image {
-  max-width: 100%;
-  height: auto;
-  border-radius: 12px;
-  margin: 20px 0;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
-}
-
-.article-content .patchnote-image {
-  display: block;
+  .patchnote-page .article-title {
+    font-size: 20px;
+  }
 }

--- a/src/styles/TeacherPatchNote.css
+++ b/src/styles/TeacherPatchNote.css
@@ -1,166 +1,171 @@
-/* Teacher 전용 패치노트 페이지 스타일 */
+/* Teacher 전용 패치노트 페이지 스타일
+   - 대시보드/사이드바/탑바 톤의 디자인 토큰 적용 (배경 #fafafa, 카드 보더 중심, 그림자 없음)
+   - 모든 선택자는 .teacher-patchnote-page 하위로 스코핑하여 다른 페이지와의 충돌 방지 */
 
 .teacher-patchnote-page {
   min-height: 100%;
-  background: #f8f9fa;
-}
-
-.teacher-patchnote-loading {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  min-height: 400px;
-  gap: 16px;
-  color: #6b7280;
-}
-
-.teacher-patchnote-loading .loading-spinner {
-  width: 40px;
-  height: 40px;
-  border: 3px solid #e5e7eb;
-  border-top-color: #6d23ed;
-  border-radius: 50%;
-  animation: spin 1s linear infinite;
-}
-
-/* 스켈레톤 로딩 */
-.skeleton {
-  background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%);
-  background-size: 200% 100%;
-  animation: skeleton-loading 1.5s infinite;
-  border-radius: 4px;
-}
-
-@keyframes skeleton-loading {
-  0% { background-position: 200% 0; }
-  100% { background-position: -200% 0; }
-}
-
-.article-content-skeleton {
-  padding: 32px;
-}
-
-.skeleton-line {
-  height: 16px;
-  margin-bottom: 12px;
-  border-radius: 4px;
-}
-
-.skeleton-line.title {
-  height: 24px;
-  width: 60%;
-  margin-bottom: 20px;
-}
-
-.skeleton-line.short {
-  width: 40%;
-}
-
-.skeleton-line.medium {
-  width: 70%;
-}
-
-.skeleton-line.long {
-  width: 90%;
-}
-
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-/* 헤더 */
-.teacher-patchnote-header {
-  background: linear-gradient(135deg, #6d23ed 0%, #9747ff 100%);
   padding: 32px 40px;
-  color: white;
+  background: #fafafa;
+}
+
+/* 페이지 헤더 */
+.teacher-patchnote-header {
+  width: min(1180px, 100%);
+  margin: 0 auto 32px;
 }
 
 .teacher-patchnote-header .header-info h1 {
-  font-size: 24px;
-  font-weight: 700;
-  margin: 0 0 8px 0;
+  margin: 0;
+  font-size: 26px;
+  font-weight: 800;
+  letter-spacing: -0.3px;
+  color: #0f0f10;
 }
 
 .teacher-patchnote-header .header-info p {
+  margin: 6px 0 0;
   font-size: 14px;
-  opacity: 0.9;
-  margin: 0;
+  font-weight: 500;
+  color: #747678;
 }
 
 /* 컨테이너 */
 .teacher-patchnote-container {
+  width: min(1180px, 100%);
+  margin: 0 auto;
+}
+
+/* 로딩 스켈레톤 (페이지 스코프 내에서만 적용) */
+.teacher-patchnote-page .skeleton {
+  background: linear-gradient(90deg, #f1f1f3 25%, #e9e9ec 50%, #f1f1f3 75%);
+  background-size: 200% 100%;
+  animation: tpn-skeleton-loading 1.5s infinite ease-in-out;
+  border-radius: 4px;
+}
+
+@keyframes tpn-skeleton-loading {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+.teacher-patchnote-page .article-content-skeleton {
   padding: 24px;
+}
+
+.teacher-patchnote-page .skeleton-line {
+  height: 14px;
+  margin-bottom: 12px;
+  border-radius: 4px;
+}
+
+.teacher-patchnote-page .skeleton-line.title {
+  height: 22px;
+  width: 60%;
+  margin-bottom: 20px;
+}
+
+.teacher-patchnote-page .skeleton-line.short {
+  width: 40%;
+}
+
+.teacher-patchnote-page .skeleton-line.medium {
+  width: 70%;
+}
+
+.teacher-patchnote-page .skeleton-line.long {
+  width: 90%;
 }
 
 /* 레이아웃 */
 .teacher-patchnote-layout {
   display: flex;
+  align-items: flex-start;
   gap: 24px;
-  max-width: 1400px;
-  margin: 0 auto;
 }
 
-/* 사이드바 */
+/* 버전 목록 사이드바 */
 .teacher-patchnote-sidebar {
   width: 280px;
   flex-shrink: 0;
-  background: white;
+  background: #ffffff;
+  border: 1px solid #e5e5e5;
   border-radius: 12px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
   overflow: hidden;
+  position: sticky;
+  top: 24px;
 }
 
 .teacher-patchnote-sidebar .sidebar-header {
-  padding: 20px;
-  border-bottom: 1px solid #e5e7eb;
+  padding: 14px 16px;
+  border-bottom: 1px solid #ececef;
   display: flex;
   justify-content: space-between;
   align-items: center;
 }
 
 .teacher-patchnote-sidebar .sidebar-header h2 {
-  font-size: 16px;
-  font-weight: 600;
   margin: 0;
-  color: #1f2937;
+  font-size: 17px;
+  font-weight: 700;
+  color: #0f0f10;
 }
 
 .teacher-patchnote-sidebar .version-count {
+  padding: 3px 9px;
+  background: #f4f4f5;
+  border-radius: 999px;
   font-size: 12px;
-  color: #6b7280;
-  background: #f3f4f6;
-  padding: 4px 8px;
-  border-radius: 12px;
+  font-weight: 600;
+  color: #747678;
 }
 
 .teacher-patchnote-sidebar .version-list {
-  max-height: calc(100vh - 300px);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-height: calc(100vh - 320px);
   overflow-y: auto;
+  padding: 8px;
 }
 
 .teacher-patchnote-sidebar .version-item {
   display: block;
   width: 100%;
-  padding: 14px 16px;
+  padding: 11px 12px;
   border: none;
-  background: none;
+  border-radius: 8px;
+  background: transparent;
   text-align: left;
   cursor: pointer;
-  border-bottom: 1px solid #f3f4f6;
-  transition: background 0.15s;
+  font-family: inherit;
   box-sizing: border-box;
+  transition: background-color 0.15s ease;
 }
 
 .teacher-patchnote-sidebar .version-item:hover {
-  background: #f9fafb;
+  background: #f4f4f5;
+}
+
+.teacher-patchnote-sidebar .version-item:focus-visible {
+  outline: 2px solid #6d23ed;
+  outline-offset: 2px;
 }
 
 .teacher-patchnote-sidebar .version-item.active {
-  background: #f3e8ff;
-  border-left: 3px solid #6d23ed;
+  background: #ede9fe;
+}
+
+.teacher-patchnote-sidebar .version-item.active .version-number,
+.teacher-patchnote-sidebar .version-item.active .version-item-title {
+  color: #6d23ed;
+}
+
+.teacher-patchnote-sidebar .version-item.active .version-item-date {
+  color: rgba(109, 35, 237, 0.7);
 }
 
 /* 스켈레톤 아이템 */
@@ -177,42 +182,46 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 6px;
+  gap: 8px;
 }
 
 .teacher-patchnote-sidebar .version-item-header-left {
   display: flex;
   align-items: center;
   gap: 6px;
+  min-width: 0;
 }
 
 .teacher-patchnote-sidebar .version-number {
-  font-size: 13px;
-  font-weight: 600;
+  font-size: 12px;
+  font-weight: 800;
   color: #6d23ed;
+  white-space: nowrap;
 }
 
 .teacher-patchnote-sidebar .category-dot {
   width: 8px;
   height: 8px;
+  flex-shrink: 0;
   border-radius: 50%;
 }
 
 .teacher-patchnote-sidebar .version-item-title {
+  margin: 6px 0 0;
   font-size: 13px;
-  font-weight: 500;
-  color: #374151;
-  margin: 8px 0 0 0;
+  font-weight: 600;
+  color: #3f3f46;
+  line-height: 1.45;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
-  line-height: 1.4;
 }
 
 .teacher-patchnote-sidebar .version-item-date {
-  font-size: 11px;
-  color: #9ca3af;
+  font-size: 12px;
+  font-weight: 600;
+  color: #747678;
   white-space: nowrap;
 }
 
@@ -223,127 +232,153 @@
 }
 
 .teacher-patchnote-article {
-  background: white;
+  background: #ffffff;
+  border: 1px solid #e5e5e5;
   border-radius: 12px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
   overflow: hidden;
 }
 
 .teacher-patchnote-article .article-header {
-  padding: 32px;
-  border-bottom: 1px solid #e5e7eb;
+  padding: 24px;
+  border-bottom: 1px solid #ececef;
 }
 
 .teacher-patchnote-article .article-meta {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
-  margin-bottom: 16px;
+  margin-bottom: 14px;
 }
 
-.teacher-patchnote-article .category-badge {
+/* 뱃지 공통 형태 (카테고리 색상은 인라인 토큰 유지) */
+.teacher-patchnote-article .category-badge,
+.teacher-patchnote-article .version-badge,
+.teacher-patchnote-article .visibility-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: 999px;
   font-size: 12px;
-  font-weight: 600;
-  padding: 4px 12px;
-  border-radius: 20px;
+  font-weight: 700;
+  line-height: 1.3;
+  white-space: nowrap;
 }
 
 .teacher-patchnote-article .version-badge {
-  font-size: 12px;
-  font-weight: 600;
-  color: #6d23ed;
-  background: #f3e8ff;
-  padding: 4px 12px;
-  border-radius: 20px;
-}
-
-.teacher-patchnote-article .visibility-badge {
-  font-size: 12px;
-  font-weight: 500;
-  padding: 4px 12px;
-  border-radius: 20px;
+  color: #52525b;
+  background: #f4f4f5;
 }
 
 .teacher-patchnote-article .visibility-badge.teacher {
-  color: #7c3aed;
+  color: #6d23ed;
   background: #ede9fe;
 }
 
 .teacher-patchnote-article .article-title {
-  font-size: 28px;
-  font-weight: 700;
-  color: #1f2937;
-  margin: 0 0 12px 0;
+  margin: 0 0 10px;
+  font-size: 24px;
+  font-weight: 800;
+  letter-spacing: -0.3px;
+  line-height: 1.35;
+  color: #0f0f10;
 }
 
 .teacher-patchnote-article .article-info {
   display: flex;
-  gap: 16px;
-  font-size: 14px;
-  color: #6b7280;
+  align-items: center;
+  gap: 12px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #747678;
 }
 
+.teacher-patchnote-article .article-author::before {
+  content: '·';
+  margin-right: 12px;
+}
+
+/* 마크다운 아티클 타이포그래피 */
 .teacher-patchnote-article .article-content {
-  padding: 32px;
+  padding: 24px;
   font-size: 15px;
-  line-height: 1.8;
-  color: #374151;
+  font-weight: 500;
+  line-height: 1.7;
+  color: #3f3f46;
+}
+
+.teacher-patchnote-article .article-content > :first-child {
+  margin-top: 0;
+}
+
+.teacher-patchnote-article .article-content > :last-child {
+  margin-bottom: 0;
 }
 
 .teacher-patchnote-article .article-content h1 {
+  margin: 28px 0 12px;
   font-size: 24px;
-  font-weight: 700;
-  color: #1f2937;
-  margin: 16px 0 12px;
-}
-
-.teacher-patchnote-article .article-content h1:first-child {
-  margin-top: 0;
+  font-weight: 800;
+  letter-spacing: -0.3px;
+  line-height: 1.35;
+  color: #0f0f10;
 }
 
 .teacher-patchnote-article .article-content h2 {
+  margin: 28px 0 12px;
   font-size: 20px;
-  font-weight: 600;
-  color: #1f2937;
-  margin: 14px 0 10px;
-}
-
-.teacher-patchnote-article .article-content h2:first-child {
-  margin-top: 0;
+  font-weight: 800;
+  letter-spacing: -0.3px;
+  line-height: 1.4;
+  color: #0f0f10;
 }
 
 .teacher-patchnote-article .article-content h3 {
+  margin: 20px 0 8px;
   font-size: 17px;
-  font-weight: 600;
-  color: #374151;
-  margin: 12px 0 8px;
+  font-weight: 700;
+  color: #0f0f10;
 }
 
-.teacher-patchnote-article .article-content h3:first-child {
-  margin-top: 0;
+.teacher-patchnote-article .article-content h4,
+.teacher-patchnote-article .article-content h5,
+.teacher-patchnote-article .article-content h6 {
+  margin: 16px 0 8px;
+  font-size: 15px;
+  font-weight: 700;
+  color: #3f3f46;
+}
+
+.teacher-patchnote-article .article-content p {
+  margin: 10px 0;
+}
+
+.teacher-patchnote-article .article-content ul,
+.teacher-patchnote-article .article-content ol {
+  margin: 10px 0;
+  padding-left: 22px;
 }
 
 .teacher-patchnote-article .article-content ul {
-  padding-left: 24px;
-  margin: 8px 0;
   list-style-type: disc;
 }
 
 .teacher-patchnote-article .article-content li {
-  margin: 2px 0;
-  line-height: 1.5;
+  margin: 4px 0;
+  line-height: 1.6;
 }
 
-.teacher-patchnote-article .article-content code {
-  background: #f3f4f6;
-  padding: 2px 6px;
-  border-radius: 4px;
-  font-family: 'Fira Code', monospace;
-  font-size: 13px;
+.teacher-patchnote-article .article-content li::marker {
+  color: #6d23ed;
+}
+
+.teacher-patchnote-article .article-content strong {
+  font-weight: 700;
+  color: #0f0f10;
 }
 
 .teacher-patchnote-article .article-content a {
   color: #6d23ed;
+  font-weight: 600;
   text-decoration: none;
 }
 
@@ -351,52 +386,149 @@
   text-decoration: underline;
 }
 
-.teacher-patchnote-article .article-content .patchnote-image {
-  max-width: 100%;
-  border-radius: 8px;
-  margin: 16px 0;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+.teacher-patchnote-article .article-content code {
+  padding: 2px 6px;
+  background: #f4f4f5;
+  border-radius: 6px;
+  font-family: 'SF Mono', 'Menlo', 'Monaco', 'Fira Code', monospace;
+  font-size: 13px;
+  color: #6d23ed;
 }
 
-/* Empty & No Selection */
+.teacher-patchnote-article .article-content pre {
+  margin: 12px 0;
+  padding: 12px 16px;
+  background: #f4f4f5;
+  border-radius: 8px;
+  overflow-x: auto;
+}
+
+.teacher-patchnote-article .article-content pre code {
+  padding: 0;
+  background: transparent;
+  border-radius: 0;
+  color: #3f3f46;
+}
+
+.teacher-patchnote-article .article-content blockquote {
+  margin: 12px 0;
+  padding: 2px 0 2px 14px;
+  border-left: 3px solid #e5e5e5;
+  color: #747678;
+}
+
+.teacher-patchnote-article .article-content hr {
+  margin: 20px 0;
+  border: none;
+  border-top: 1px solid #ececef;
+}
+
+.teacher-patchnote-article .article-content table {
+  width: 100%;
+  margin: 12px 0;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.teacher-patchnote-article .article-content th,
+.teacher-patchnote-article .article-content td {
+  padding: 8px 12px;
+  border: 1px solid #ececef;
+  text-align: left;
+}
+
+.teacher-patchnote-article .article-content th {
+  background: #fafafa;
+  color: #0f0f10;
+  font-weight: 700;
+}
+
+.teacher-patchnote-article .article-content .patchnote-image {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  margin: 16px 0;
+  border: 1px solid #ececef;
+  border-radius: 8px;
+}
+
+/* 빈 상태 & 미선택 상태 */
 .teacher-patchnote-container .empty-state,
 .teacher-patchnote-main .no-selection {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
   text-align: center;
-  padding: 80px 40px;
-  background: white;
-  border-radius: 12px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  padding: 64px 32px;
+  background: #ffffff;
+  border: 1px dashed #d8d2e7;
+  border-radius: 10px;
+}
+
+.teacher-patchnote-main .no-selection {
+  min-height: 360px;
 }
 
 .teacher-patchnote-container .empty-state .empty-icon {
-  font-size: 48px;
-  margin-bottom: 16px;
+  font-size: 36px;
+  margin-bottom: 12px;
 }
 
 .teacher-patchnote-container .empty-state h3 {
-  font-size: 18px;
-  font-weight: 600;
-  color: #1f2937;
-  margin: 0 0 8px;
+  margin: 0 0 6px;
+  font-size: 15px;
+  font-weight: 700;
+  color: #0f0f10;
 }
 
 .teacher-patchnote-container .empty-state p,
 .teacher-patchnote-main .no-selection p {
-  color: #6b7280;
   margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: #747678;
 }
 
 /* 반응형 */
 @media (max-width: 900px) {
+  .teacher-patchnote-page {
+    padding: 24px 20px;
+  }
+
+  .teacher-patchnote-header {
+    margin-bottom: 24px;
+  }
+
   .teacher-patchnote-layout {
     flex-direction: column;
   }
-  
+
   .teacher-patchnote-sidebar {
+    position: static;
     width: 100%;
   }
-  
+
   .teacher-patchnote-sidebar .version-list {
-    max-height: 200px;
+    max-height: 220px;
+  }
+}
+
+@media (max-width: 480px) {
+  .teacher-patchnote-page {
+    padding: 20px 14px;
+  }
+
+  .teacher-patchnote-header .header-info h1 {
+    font-size: 22px;
+  }
+
+  .teacher-patchnote-article .article-header,
+  .teacher-patchnote-article .article-content {
+    padding: 16px;
+  }
+
+  .teacher-patchnote-article .article-title {
+    font-size: 20px;
   }
 }

--- a/src/styles/TeacherPatchNote.css
+++ b/src/styles/TeacherPatchNote.css
@@ -96,7 +96,7 @@
   border-radius: 12px;
   overflow: hidden;
   position: sticky;
-  top: 24px;
+  top: calc(60px + 24px);
 }
 
 .teacher-patchnote-sidebar .sidebar-header {


### PR DESCRIPTION
## Closes #80

## 변경사항

- 선생님용 패치노트 페이지: 보라 그라데이션 헤더 제거 후 대시보드형 플레인 헤더로 교체, 좌측 버전 목록 사이드바(버전 뱃지·카테고리 도트·날짜)를 inset 라운드 행으로 정리
- 공개용 패치노트 페이지: 다크 히어로 헤더/푸터를 탑바 톤(흰 배경+크롬 보더)으로 변경, Qvick 로고·브랜드 텍스트 조정, 장식 요소를 저알파 워시로 개선
- 카테고리/버전/Teacher 전용 뱃지 색상 체계 정리(999px pill), 마크다운 아티클 타이포그래피(h2/h3/본문/코드블록/quote/table) 정리
- 로딩 스켈레톤·빈 상태·미선택 상태를 점선 보더 토큰으로 통일, keyframes를 페이지별 고유명으로 분리해 충돌 제거

## 스크린샷/동영상

(추후 첨부 예정)

## 참고 사항

- 두 페이지 모두 CSS만 변경, TSX·API 로직 무변경. `npm run lint`, `npm run build` 통과
- 카테고리 뱃지 색상은 컴포넌트 내 CATEGORY_CONFIG 값을 그대로 사용해 기존 팔레트 유지
