### PR TITLE
feat: 전체 페이지 디자인 변경 및 공통 UI 개선

### DIFF
--- a/src/pages/Check.tsx
+++ b/src/pages/Check.tsx
@@ -390,9 +390,9 @@ export default function Check() {
 
   useEffect(() => {
     setHeaderActions(
-      <div className="header-attendance-period-controls">
+      <div className="header-attendance-period-controls check-period-controls">
         <span
-          className={`header-attendance-period-summary ${
+          className={`header-attendance-period-summary check-period-summary ${
             isViewingCurrentAttendancePeriod ? 'is-current' : ''
           }`}
         >
@@ -402,19 +402,19 @@ export default function Check() {
           <span>{ATTENDANCE_PERIOD_LABELS[attendanceType].title}</span>
         </span>
         <div
-          className="header-attendance-period-navigation"
+          className="header-attendance-period-navigation check-period-navigation"
           aria-label="점호 회차 이동"
         >
           <button
             type="button"
-            className="header-attendance-period-button"
+            className="header-attendance-period-button check-period-button"
             onClick={handlePreviousAttendancePeriod}
           >
             ← 이전 점호
           </button>
           <button
             type="button"
-            className="header-attendance-period-button"
+            className="header-attendance-period-button check-period-button"
             onClick={handleNextAttendancePeriod}
           >
             다음 점호 →

--- a/src/pages/Check.tsx
+++ b/src/pages/Check.tsx
@@ -407,14 +407,14 @@ export default function Check() {
         >
           <button
             type="button"
-            className="header-attendance-period-button check-period-button"
+            className="header-attendance-period-button"
             onClick={handlePreviousAttendancePeriod}
           >
             ← 이전 점호
           </button>
           <button
             type="button"
-            className="header-attendance-period-button check-period-button"
+            className="header-attendance-period-button"
             onClick={handleNextAttendancePeriod}
           >
             다음 점호 →

--- a/src/pages/NightStudy.tsx
+++ b/src/pages/NightStudy.tsx
@@ -307,7 +307,7 @@ export default function NightStudy() {
           </thead>
           <tbody>
             {isLoading ? (
-              <tr>
+              <tr className="sleepover-empty-row">
                 <td colSpan={6} className="sleepover-empty-cell">
                   심야자습 현황을 불러오는 중입니다.
                 </td>
@@ -328,7 +328,7 @@ export default function NightStudy() {
                 </tr>
               ))
             ) : (
-              <tr>
+              <tr className="sleepover-empty-row">
                 <td colSpan={6} className="sleepover-empty-cell">
                   조건에 맞는 학생이 없습니다.
                 </td>

--- a/src/pages/PhoneSubmission.tsx
+++ b/src/pages/PhoneSubmission.tsx
@@ -325,7 +325,7 @@ export default function PhoneSubmission() {
           </thead>
           <tbody>
             {isLoading ? (
-              <tr>
+              <tr className="sleepover-empty-row">
                 <td colSpan={7} className="sleepover-empty-cell">
                   휴대폰 제출 현황을 불러오는 중입니다.
                 </td>
@@ -366,7 +366,7 @@ export default function PhoneSubmission() {
                 </tr>
               ))
             ) : (
-              <tr>
+              <tr className="sleepover-empty-row">
                 <td colSpan={7} className="sleepover-empty-cell">
                   조건에 맞는 학생이 없습니다.
                 </td>

--- a/src/pages/Sleepover.tsx
+++ b/src/pages/Sleepover.tsx
@@ -207,7 +207,7 @@ export default function Sleepover() {
           </thead>
           <tbody>
             {isLoading ? (
-              <tr>
+              <tr className="sleepover-empty-row">
                 <td colSpan={7} className="sleepover-empty-cell">
                   외박자 목록을 불러오는 중입니다.
                 </td>
@@ -249,7 +249,7 @@ export default function Sleepover() {
                 );
               })
             ) : (
-              <tr>
+              <tr className="sleepover-empty-row">
                 <td colSpan={7} className="sleepover-empty-cell">
                   외박자가 없습니다.
                 </td>

--- a/src/styles/Check.css
+++ b/src/styles/Check.css
@@ -614,7 +614,7 @@
   text-align: center;
 }
 
-.check-page .student-table tbody tr:not(:has(td[colspan])):hover td {
+.check-page .student-table tbody tr:not(.sleepover-empty-row):hover td {
   background: #fafafa;
 }
 
@@ -948,7 +948,7 @@
     background: #ffffff;
   }
 
-  .check-page .student-table tbody tr:not(:has(td[colspan])):hover td {
+  .check-page .student-table tbody tr:not(.sleepover-empty-row):hover td {
     background: transparent;
   }
 

--- a/src/styles/Check.css
+++ b/src/styles/Check.css
@@ -1,66 +1,99 @@
-/* Check Page Styles */
+/* =========================================================
+   Check Page 공용 스타일
+   - 인원 확인 / 심야자습 / 휴대폰 제출 / (외박·자치위원) 페이지가 공유
+   - 모든 선택자는 .check-page 하위로 스코핑하여 전역 오염 방지
+   ========================================================= */
+
 .check-page {
+  min-height: 100%;
   padding: 32px 40px;
+  background: #fafafa;
 }
 
+/* 콘텐츠 최대폭 1180px 중앙정렬 */
+.check-page .controls-section,
+.check-page .filter-section,
+.check-page .table-container,
+.check-page .check-skeleton {
+  width: min(1180px, 100%);
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.check-page .check-skeleton {
+  margin-bottom: 32px;
+}
+
+/* ===== 상단 컨트롤 (날짜 · 검색 · 통계) ===== */
 .check-page .controls-section {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 24px;
-  gap: 24px;
+  gap: 20px;
+  margin-bottom: 32px;
 }
 
 .check-page .controls-left {
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: 12px;
 }
 
 .check-page .date-picker input {
-  padding: 10px 16px;
-  border: 2px solid #e6e6e7;
-  border-radius: 12px;
-  font-size: 15px;
-  font-weight: 500;
-  color: #0f0f10;
+  min-height: 40px;
+  padding: 8px 12px;
+  border: 1px solid #e4e4e7;
+  border-radius: 10px;
   background: #ffffff;
+  font-size: 13px;
+  font-weight: 600;
+  color: #0f0f10;
   cursor: pointer;
-  transition: all 0.2s;
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
 }
 
 .check-page .date-picker input:hover {
-  border-color: #6d23ed;
+  border-color: #c9c9cc;
 }
 
 .check-page .date-picker input:focus {
   outline: none;
   border-color: #6d23ed;
-  box-shadow: 0 0 0 3px rgba(109, 35, 237, 0.1);
+  box-shadow: 0 0 0 3px rgba(109, 35, 237, 0.12);
 }
 
 .check-page .search-box {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
+  width: 280px;
+  min-height: 40px;
+  padding: 0 14px;
+  border: 1px solid #e4e4e7;
+  border-radius: 10px;
   background: #ffffff;
-  border: 2px solid #e6e6e7;
-  border-radius: 12px;
-  padding: 10px 16px;
-  width: 300px;
-  transition: all 0.2s;
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+.check-page .search-box:hover {
+  border-color: #c9c9cc;
 }
 
 .check-page .search-box:focus-within {
   border-color: #6d23ed;
-  box-shadow: 0 0 0 3px rgba(109, 35, 237, 0.1);
+  box-shadow: 0 0 0 3px rgba(109, 35, 237, 0.12);
 }
 
-.search-icon {
-  width: 20px;
-  height: 20px;
+.check-page .search-icon {
+  width: 18px;
+  height: 18px;
   flex-shrink: 0;
-  color: #9e9e9f;
+  color: #a1a1aa;
+  transition: color 0.15s ease;
 }
 
 .check-page .search-box:focus-within .search-icon {
@@ -70,18 +103,20 @@
 .check-page .search-box input {
   border: none;
   background: transparent;
-  font-size: 15px;
+  font-size: 13px;
   font-weight: 500;
   color: #0f0f10;
   outline: none;
   flex: 1;
+  min-width: 0;
 }
 
 .check-page .search-box input::placeholder {
-  color: #9e9e9f;
-  font-weight: 400;
+  color: #a1a1aa;
+  font-weight: 500;
 }
 
+/* 통계 박스 */
 .check-page .stats-section {
   display: flex;
   gap: 10px;
@@ -92,215 +127,233 @@
 }
 
 .check-page .stat-box {
+  padding: 12px 16px;
+  border: 1px solid #e5e5e5;
+  border-radius: 12px;
   background: #ffffff;
-  padding: 7px 20px;
-  border-radius: 8px;
-  font-size: 16px;
-  font-weight: 500;
+  font-size: 13px;
+  font-weight: 600;
+  color: #52525b;
   white-space: nowrap;
+  transition: border-color 0.15s ease;
+}
+
+.check-page .stat-box:hover {
+  border-color: #c9c9cc;
 }
 
 .check-page .stat-box .positive {
-  color: #00bf40;
+  color: #22c55e;
+  font-weight: 700;
 }
 
 .check-page .stat-box .negative {
-  color: #e1322e;
+  color: #ef4444;
+  font-weight: 700;
 }
 
 .check-page .stat-box .warning {
   color: #f59e0b;
+  font-weight: 700;
 }
 
 .check-page .stat-box .sleepover-count {
   color: #8b5cf6;
+  font-weight: 700;
 }
 
 .check-page .stat-box .phone-submission-count {
-  color: #e1322e;
-}
-
-.check-page .excel-button {
-  min-height: 38px;
-  background: #164e8d;
-  color: #ffffff;
-  border: 1px solid #164e8d;
-  border-radius: 8px;
-  padding: 0 14px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  font-size: 14px;
+  color: #ef4444;
   font-weight: 700;
-  cursor: pointer;
-  transition:
-    background-color 0.2s,
-    border-color 0.2s,
-    opacity 0.2s;
-  white-space: nowrap;
 }
 
-.check-page .excel-button:hover {
-  background: #1a5aa1;
-  border-color: #1a5aa1;
-}
-
-.check-page .excel-button:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-}
-
+/* ===== 엑셀 내보내기 드롭다운 ===== */
 .check-page .excel-dropdown {
   position: relative;
 }
 
-.excel-menu {
+.check-page .excel-button {
+  min-height: 40px;
+  padding: 0 16px;
+  border: 1px solid #6d23ed;
+  border-radius: 8px;
+  background: #6d23ed;
+  color: #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  white-space: nowrap;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease,
+    opacity 0.15s ease;
+}
+
+.check-page .excel-button:hover:not(:disabled) {
+  background: #5919c7;
+  border-color: #5919c7;
+}
+
+.check-page .excel-button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.check-page .excel-icon {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  color: #ffffff;
+}
+
+.check-page .excel-caret {
+  font-size: 11px;
+  line-height: 1;
+}
+
+.check-page .excel-menu {
   position: absolute;
   top: 100%;
   right: 0;
-  margin-top: 8px;
-  padding: 8px;
-  background: #ffffff;
-  border: 1px solid #e6e6e7;
-  border-radius: 8px;
-  box-shadow: 0 16px 36px rgba(15, 15, 16, 0.16);
   z-index: 10;
-  min-width: 220px;
+  min-width: 240px;
+  margin-top: 8px;
+  padding: 6px;
+  border: 1px solid #e5e5e5;
+  border-radius: 10px;
+  background: #ffffff;
+  box-shadow: 0 12px 28px rgba(15, 15, 16, 0.1);
 }
 
-.excel-menu-header {
+.check-page .excel-menu-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
   padding: 8px 10px 10px;
-  font-size: 13px;
-  font-weight: 800;
+  border-bottom: 1px solid #ececef;
   color: #6d23ed;
-  border-bottom: 1px solid #e5e7eb;
+  font-size: 12px;
+  font-weight: 800;
 }
 
-.excel-menu-header-action {
+.check-page .excel-menu-header-action {
+  padding: 2px 6px;
   border: none;
+  border-radius: 6px;
   background: transparent;
   color: #747678;
   font-size: 12px;
   font-weight: 700;
   cursor: pointer;
+  transition: color 0.15s ease, background-color 0.15s ease;
 }
 
-.excel-menu-header-action:hover {
+.check-page .excel-menu-header-action:hover {
   color: #6d23ed;
+  background: rgba(109, 35, 237, 0.06);
 }
 
-.excel-menu-item {
+.check-page .excel-menu-item {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 3px;
   width: 100%;
-  padding: 12px;
-  background: #ffffff;
+  padding: 10px 12px;
   border: 1px solid transparent;
   border-radius: 8px;
-  font-size: 14px;
+  background: #ffffff;
+  color: #0f0f10;
+  font-size: 13px;
   font-weight: 700;
-  color: #1f2937;
-  cursor: pointer;
   text-align: left;
+  cursor: pointer;
   transition:
-    background-color 0.2s,
-    border-color 0.2s,
-    color 0.2s;
+    background-color 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease;
 }
 
-.excel-menu-item:hover {
+.check-page .excel-menu-item:hover {
   border-color: rgba(109, 35, 237, 0.18);
   background: rgba(109, 35, 237, 0.06);
 }
 
-.excel-menu-item + .excel-menu-item {
-  margin-top: 6px;
+.check-page .excel-menu-item + .excel-menu-item {
+  margin-top: 4px;
 }
 
-.excel-menu-item.absent-only {
-  color: #e1322e;
+.check-page .excel-menu-item-title {
+  font-size: 13px;
+  font-weight: 700;
 }
 
-.excel-menu-item.absent-only:hover {
-  border-color: rgba(225, 50, 46, 0.2);
-  background: rgba(225, 50, 46, 0.08);
-}
-
-.excel-menu-item.sleepover-only {
-  color: #6d23ed;
-}
-
-.excel-menu-item.sleepover-only:hover {
-  border-color: rgba(109, 35, 237, 0.22);
-  background: rgba(109, 35, 237, 0.08);
-}
-
-.excel-menu-item-title {
-  font-size: 14px;
-  font-weight: 800;
-}
-
-.excel-menu-item-desc {
+.check-page .excel-menu-item-desc {
   color: #747678;
   font-size: 12px;
   font-weight: 600;
   line-height: 1.35;
 }
 
-.excel-menu-item.back-button {
+.check-page .excel-menu-item.absent-only {
+  color: #b91c1c;
+}
+
+.check-page .excel-menu-item.absent-only:hover {
+  border-color: rgba(239, 68, 68, 0.2);
+  background: rgba(239, 68, 68, 0.07);
+}
+
+.check-page .excel-menu-item.sleepover-only {
+  color: #6d28d9;
+}
+
+.check-page .excel-menu-item.sleepover-only:hover {
+  border-color: rgba(139, 92, 246, 0.24);
+  background: rgba(139, 92, 246, 0.08);
+}
+
+.check-page .excel-menu-item.back-button {
   align-items: center;
+  padding: 8px 12px;
+  background: #f4f4f5;
   color: #747678;
   font-size: 13px;
-  padding: 9px 12px;
-  background: #f7f7f8;
+  font-weight: 600;
 }
 
-.excel-icon {
-  width: 18px;
-  height: 18px;
-  flex-shrink: 0;
-  color: #ffffff;
+.check-page .excel-menu-item.back-button:hover {
+  border-color: transparent;
+  background: #ececef;
 }
 
-.excel-caret {
-  font-size: 11px;
-  line-height: 1;
-}
-
-/* Filter Section */
+/* ===== 필터 섹션 ===== */
 .check-page .filter-section {
   display: flex;
-  gap: 20px;
-  margin-bottom: 20px;
-  padding: 20px;
-  background: #ffffff;
-  border-radius: 12px;
+  align-items: center;
+  gap: 20px 24px;
   flex-wrap: wrap;
-  align-items: center;
-}
-
-.check-page .filter-actions {
-  margin-left: auto;
-  display: flex;
-  align-items: center;
+  padding: 16px 20px;
+  margin-bottom: 32px;
+  border: 1px solid #e5e5e5;
+  border-radius: 12px;
+  background: #ffffff;
 }
 
 .check-page .filter-group {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 10px;
 }
 
-.filter-label {
-  font-size: 15px;
+.check-page .filter-label {
+  color: #747678;
+  font-size: 13px;
   font-weight: 600;
-  color: #0f0f10;
   white-space: nowrap;
 }
 
@@ -310,22 +363,25 @@
 }
 
 .check-page .filter-btn {
-  padding: 6px 16px;
-  border: 1px solid #e6e6e7;
-  background: #ffffff;
-  color: #5d5f60;
+  padding: 7px 14px;
+  border: 1px solid #e4e4e7;
   border-radius: 8px;
-  font-size: 14px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.2s;
+  background: #ffffff;
+  color: #52525b;
+  font-size: 13px;
+  font-weight: 600;
   white-space: nowrap;
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease;
 }
 
 .check-page .filter-btn:hover {
-  border-color: #6d23ed;
-  color: #6d23ed;
-  background: rgba(109, 35, 237, 0.05);
+  border-color: #d4d4d8;
+  background: #f4f4f5;
+  color: #3f3f46;
 }
 
 .check-page .filter-btn.active {
@@ -335,14 +391,23 @@
 }
 
 .check-page .filter-btn.active:hover {
-  background: #5919c7;
   border-color: #5919c7;
+  background: #5919c7;
+  color: #ffffff;
 }
 
+.check-page .filter-actions {
+  display: flex;
+  align-items: center;
+  margin-left: auto;
+}
+
+/* ===== 학생 테이블 ===== */
 .check-page .table-container {
-  background: #ffffff;
-  border-radius: 8px;
   overflow: hidden;
+  border: 1px solid #e5e5e5;
+  border-radius: 12px;
+  background: #ffffff;
 }
 
 .check-page .student-table {
@@ -502,47 +567,55 @@
 }
 
 .check-page .student-table thead th {
-  background: #ffffff;
-  border-bottom: 1px solid #c4c5c6;
-  padding: 13.5px 6px;
-  font-size: 15px;
+  padding: 12px 8px;
+  border-bottom: 1px solid #ececef;
+  background: #fafafa;
+  color: #747678;
+  font-size: 13px;
   font-weight: 600;
-  color: #0f0f10;
   text-align: center;
+  white-space: nowrap;
 }
 
 .check-page .student-table thead th.sortable {
-  cursor: pointer;
-  user-select: none;
   position: relative;
-  transition: background-color 0.2s;
   padding-left: 18px;
   padding-right: 18px;
+  cursor: pointer;
+  user-select: none;
+  transition: background-color 0.15s ease, color 0.15s ease;
 }
 
 .check-page .student-table thead th.sortable:hover {
-  background: #f5f5f5;
+  background: #f4f4f5;
+  color: #3f3f46;
 }
 
 .check-page .student-table thead th.sortable:active {
-  background: #eeeeee;
+  background: #ececef;
 }
 
-.sort-indicator {
-  font-size: 12px;
-  color: #6d23ed;
+.check-page .sort-indicator {
   position: absolute;
   right: 8px;
   top: 50%;
   transform: translateY(-50%);
+  color: #6d23ed;
+  font-size: 11px;
+  line-height: 1;
 }
 
 .check-page .student-table tbody td {
-  padding: 12px 6px;
-  border-bottom: 1px solid #c4c5c6;
-  font-size: 16px;
+  padding: 13px 8px;
+  border-bottom: 1px solid #f4f4f5;
+  color: #3f3f46;
+  font-size: 13px;
+  font-weight: 500;
   text-align: center;
-  color: #0f0f10;
+}
+
+.check-page .student-table tbody tr:not(:has(td[colspan])):hover td {
+  background: #fafafa;
 }
 
 .check-page .student-table thead th:first-child,
@@ -561,120 +634,186 @@
   border-bottom: none;
 }
 
-.room-cell {
-  font-weight: 500;
-}
-
-.status-present {
-  color: #00bf40;
+.check-page .room-cell {
+  color: #0f0f10;
   font-weight: 600;
 }
 
-.status-absent {
-  color: #ff4242;
+/* 상태 텍스트 (출석/미출석/지연/외박) */
+.check-page .status-present {
+  color: #22c55e;
   font-weight: 600;
 }
 
-.status-sleepover {
+.check-page .status-absent {
+  color: #ef4444;
+  font-weight: 600;
+}
+
+.check-page .status-sleepover {
   color: #8b5cf6;
   font-weight: 600;
 }
 
-.status-late {
+.check-page .status-late {
   color: #f59e0b;
   font-weight: 600;
 }
 
+/* 행 내 상태 셀렉트 */
 .check-page .status-select {
-  border: none;
+  padding: 6px 10px;
+  border: 1px solid transparent;
+  border-radius: 8px;
   background: transparent;
-  font-size: 14px;
-  font-weight: 600;
+  color: #3f3f46;
+  font-size: 13px;
+  font-weight: 700;
   cursor: pointer;
-  padding: 2px 4px;
-  border-radius: 4px;
   outline: none;
   appearance: auto;
   text-align: center;
   text-align-last: center;
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease;
 }
 
 .check-page .status-select:disabled {
-  opacity: 0.6;
+  opacity: 0.55;
   cursor: not-allowed;
 }
 
 .check-page .status-select.status-present {
-  color: #00bf40;
+  color: #15803d;
+  background: rgba(34, 197, 94, 0.12);
 }
 
 .check-page .status-select.status-absent {
-  color: #ff4242;
+  color: #b91c1c;
+  background: rgba(239, 68, 68, 0.09);
 }
 
 .check-page .status-select.status-sleepover {
-  color: #8b5cf6;
+  color: #6d28d9;
+  background: rgba(139, 92, 246, 0.12);
 }
 
 .check-page .status-select.status-late {
-  color: #f59e0b;
+  color: #b45309;
+  background: rgba(245, 158, 11, 0.14);
 }
 
+/* 휴대폰 제출 셀렉트 */
 .check-page .phone-submission-select {
-  border: none;
+  padding: 6px 10px;
+  border: 1px solid transparent;
+  border-radius: 8px;
   background: transparent;
-  font-size: 14px;
-  font-weight: 600;
+  color: #3f3f46;
+  font-size: 13px;
+  font-weight: 700;
   cursor: pointer;
-  padding: 2px 4px;
-  border-radius: 4px;
   outline: none;
   appearance: auto;
   text-align: center;
   text-align-last: center;
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease;
 }
 
 .check-page .phone-submission-select:disabled {
-  opacity: 0.6;
+  opacity: 0.55;
   cursor: not-allowed;
 }
 
 .check-page .phone-submission-select.status-present {
-  color: #00bf40;
+  color: #15803d;
+  background: rgba(34, 197, 94, 0.12);
 }
 
 .check-page .phone-submission-select.status-absent {
-  color: #ff4242;
+  color: #b91c1c;
+  background: rgba(239, 68, 68, 0.09);
 }
 
 .check-page .phone-submission-select.status-sleepover {
-  color: #8b5cf6;
+  color: #6d28d9;
+  background: rgba(139, 92, 246, 0.12);
 }
 
-.phone-submission-badge {
+/* 휴대폰 제출 뱃지 (O / X / 외박 / -) */
+.check-page .phone-submission-badge {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 15px;
-  font-weight: 600;
-  line-height: 1;
+  padding: 3px 10px;
+  border-radius: 999px;
+  color: #747678;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.4;
   white-space: nowrap;
 }
 
-.phone-submission-badge.submitted {
-  color: #00a83a;
+.check-page .phone-submission-badge.submitted {
+  color: #15803d;
+  background: rgba(34, 197, 94, 0.12);
 }
 
-.phone-submission-badge.not-submitted {
-  color: #e1322e;
+.check-page .phone-submission-badge.not-submitted {
+  color: #b91c1c;
+  background: rgba(239, 68, 68, 0.09);
 }
 
-.phone-submission-badge.sleepover {
-  color: #6d23ed;
+.check-page .phone-submission-badge.sleepover {
+  color: #6d28d9;
+  background: rgba(139, 92, 246, 0.12);
 }
 
-.phone-submission-badge.unknown {
+.check-page .phone-submission-badge.unknown {
   color: #747678;
+  background: #f4f4f5;
+}
+
+/* 점호 회차 이동 컨트롤 (헤더 영역, Header.css 보조 정의) */
+.header-attendance-period-controls.check-period-controls {
+  gap: 10px;
+}
+
+.header-attendance-period-summary.check-period-summary {
+  color: #52525b;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.header-attendance-period-summary.check-period-summary.is-current {
+  color: #6d23ed;
+  font-weight: 700;
+}
+
+.header-attendance-period-summary.check-period-summary.is-current
+  .header-attendance-period-date {
+  background: #ede9fe;
+}
+
+.header-attendance-period-navigation.check-period-navigation {
+  padding: 3px 5px;
+  border: 1px solid #e4e4e7;
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.header-attendance-period-navigation.check-period-navigation
+  .header-attendance-period-button {
+  color: #52525b;
+}
+
+.header-attendance-period-navigation.check-period-navigation
+  .header-attendance-period-button:hover {
+  background: #ede9fe;
+  color: #6d23ed;
 }
 
 /* 반응형 디자인 */
@@ -686,6 +825,7 @@
   .check-page .controls-section {
     flex-direction: column;
     align-items: stretch;
+    margin-bottom: 24px;
   }
 
   .check-page .controls-left {
@@ -702,7 +842,7 @@
   }
 
   .check-page .stats-section {
-    flex-wrap: wrap;
+    justify-content: flex-start;
   }
 
   .check-page .stat-box {
@@ -713,6 +853,7 @@
   .check-page .filter-section {
     flex-direction: column;
     align-items: stretch;
+    margin-bottom: 24px;
   }
 
   .check-page .filter-group {
@@ -751,8 +892,11 @@
   .check-page .stats-section {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    width: 100%;
     gap: 8px;
+  }
+
+  .check-page .stat-box {
+    text-align: center;
   }
 
   .check-page .filter-section {
@@ -772,8 +916,10 @@
   }
 
   .check-page .table-container {
-    background: transparent;
     overflow: visible;
+    border: none;
+    border-radius: 0;
+    background: transparent;
   }
 
   .check-page .student-table,
@@ -797,10 +943,13 @@
 
   .check-page .student-table tbody tr {
     padding: 14px;
-    border: 1px solid #e6e6e7;
+    border: 1px solid #e5e5e5;
     border-radius: 12px;
     background: #ffffff;
-    box-shadow: 0 8px 20px rgba(15, 15, 16, 0.06);
+  }
+
+  .check-page .student-table tbody tr:not(:has(td[colspan])):hover td {
+    background: transparent;
   }
 
   .check-page .student-table tbody td {
@@ -809,16 +958,16 @@
     justify-content: space-between;
     gap: 16px;
     padding: 10px 0;
-    border-bottom: 1px solid #f0f0f1;
-    font-size: 15px;
+    border-bottom: 1px solid #f4f4f5;
+    font-size: 13px;
     text-align: right;
   }
 
   .check-page .student-table tbody td::before {
     content: attr(data-label);
     color: #747678;
-    font-size: 13px;
-    font-weight: 700;
+    font-size: 12px;
+    font-weight: 600;
     text-align: left;
   }
 
@@ -839,7 +988,6 @@
     max-width: 160px;
     text-align: right;
   }
-
 }
 
 @media (max-width: 480px) {
@@ -848,12 +996,12 @@
   }
 
   .check-page .stat-box {
-    font-size: 14px;
-    padding: 8px 10px;
+    padding: 10px 12px;
+    font-size: 12px;
   }
 
   .check-page .excel-button {
-    font-size: 16px;
+    font-size: 13px;
     padding: 8px 10px;
   }
 
@@ -871,5 +1019,4 @@
   .check-page .status-select {
     max-width: 100%;
   }
-
 }

--- a/src/styles/Notice.css
+++ b/src/styles/Notice.css
@@ -6,364 +6,313 @@
   color: #0f0f10;
 }
 
-.notice-page-header,
-.notice-toolbar,
-.selection-action-bar,
-.notice-card {
-  border: 1px solid #e6e6e7;
-  border-radius: 12px;
-  background: #ffffff;
-  box-shadow: 0 4px 16px rgba(15, 15, 16, 0.04);
+.notice-page > .notice-page-header,
+.notice-page > .notice-toolbar,
+.notice-page > .notice-list-header,
+.notice-page > .notice-grid {
+  width: min(1180px, 100%);
+  margin-left: auto;
+  margin-right: auto;
 }
 
-.notice-page-header {
+.notice-page .notice-page-header {
   display: flex;
-  align-items: center;
+  align-items: flex-end;
   justify-content: space-between;
   gap: 24px;
-  margin-bottom: 16px;
-  padding: 28px 30px;
-  background:
-    linear-gradient(90deg, rgba(109, 35, 237, 0.1), rgba(109, 35, 237, 0) 46%),
-    #ffffff;
+  margin-bottom: 32px;
 }
 
-.notice-kicker {
+.notice-page .notice-kicker {
+  display: block;
   color: #6d23ed;
-  font-size: 13px;
-  font-weight: 800;
-  letter-spacing: 0;
+  font-size: 12px;
+  font-weight: 700;
 }
 
-.page-title {
+.notice-page .page-title {
   margin: 6px 0 8px;
   color: #0f0f10;
-  font-size: 30px;
+  font-size: 26px;
   font-weight: 800;
-  line-height: 1.2;
-  letter-spacing: 0;
+  line-height: 1.25;
+  letter-spacing: -0.3px;
 }
 
-.notice-page-description {
-  color: #5d5f60;
-  font-size: 15px;
+.notice-page .notice-page-description {
+  margin: 0;
+  color: #747678;
+  font-size: 14px;
   font-weight: 500;
   line-height: 1.55;
 }
 
-.create-button,
-.select-all-button,
-.action-button {
-  min-height: 40px;
-  border-radius: 8px;
-  font-size: 14px;
-  font-weight: 700;
-  cursor: pointer;
-  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
-}
-
-.create-button {
+.notice-page .create-button {
   flex-shrink: 0;
+  min-height: 40px;
   border: 1px solid #6d23ed;
+  border-radius: 8px;
   background: #6d23ed;
   color: #ffffff;
   padding: 0 18px;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease;
 }
 
-.create-button:hover {
+.notice-page .create-button:hover:not(:disabled) {
   border-color: #5919c7;
   background: #5919c7;
-  box-shadow: 0 6px 16px rgba(109, 35, 237, 0.18);
 }
 
-.notice-toolbar {
+.notice-page .notice-toolbar {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  margin-bottom: 16px;
-  padding: 14px 16px;
+  flex-wrap: wrap;
+  gap: 12px 16px;
+  margin-bottom: 32px;
 }
 
 .notice-page .filter-section {
   min-width: 0;
   display: flex;
   align-items: center;
-  align-self: center;
-  flex: 1 1 360px;
-  gap: 6px;
   flex-wrap: wrap;
-  margin: 0;
+  gap: 6px;
 }
 
-.filter-button {
+.notice-page .filter-button {
   min-height: 34px;
-  border: 1px solid #e6e6e7;
+  border: 1px solid #e4e4e7;
   border-radius: 8px;
   background: #ffffff;
-  color: #5d5f60;
-  padding: 0 12px;
+  color: #52525b;
+  padding: 0 14px;
   font-size: 13px;
-  font-weight: 700;
+  font-weight: 600;
   cursor: pointer;
-  transition: all 0.2s;
   white-space: nowrap;
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
 }
 
-.filter-button:hover {
-  border-color: #6d23ed;
+.notice-page .filter-button:hover {
+  background: #f4f4f5;
+}
+
+.notice-page .filter-button.active {
+  border-color: #ede9fe;
+  background: #ede9fe;
   color: #6d23ed;
-  background: rgba(109, 35, 237, 0.05);
 }
 
-.filter-button.active {
-  border-color: #6d23ed;
-  background: #6d23ed;
-  color: #ffffff;
-}
-
-.notice-summary {
+.notice-page .notice-summary {
   display: flex;
   align-items: center;
-  gap: 8px;
-  flex: 0 0 auto;
   flex-wrap: wrap;
-  color: #5d5f60;
-  font-size: 13px;
-  font-weight: 700;
-}
-
-.notice-summary span {
-  min-height: 32px;
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  border-radius: 999px;
-  background: #f5f5f5;
-  padding: 0 12px;
-}
-
-.notice-summary strong {
-  color: #6d23ed;
-}
-
-.selection-action-bar {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 18px;
-  margin-bottom: 16px;
-  padding: 16px 18px;
-  border-color: rgba(109, 35, 237, 0.24);
-  background: #fbf9ff;
-}
-
-.selection-copy {
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
-}
-
-.selection-copy strong {
-  color: #0f0f10;
-  font-size: 15px;
-  font-weight: 800;
-}
-
-.selection-copy span {
+  gap: 6px;
+  flex: 0 0 auto;
   color: #747678;
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 600;
 }
 
-.selection-actions {
-  display: flex;
+.notice-page .notice-summary span {
+  min-height: 28px;
+  display: inline-flex;
   align-items: center;
-  gap: 8px;
-  flex-wrap: wrap;
-  justify-content: flex-end;
+  gap: 5px;
+  border-radius: 999px;
+  background: #f4f4f5;
+  padding: 0 11px;
 }
 
-.action-button,
-.select-all-button {
-  border: 1px solid #e6e6e7;
-  background: #ffffff;
-  color: #5d5f60;
-  padding: 0 14px;
+.notice-page .notice-summary strong {
+  color: #0f0f10;
+  font-weight: 700;
 }
 
-.action-button:hover:not(:disabled),
-.select-all-button:hover {
-  border-color: #6d23ed;
-  color: #6d23ed;
-  background: rgba(109, 35, 237, 0.05);
-}
-
-.action-button.pin {
-  border-color: #6d23ed;
-  background: #6d23ed;
-  color: #ffffff;
-}
-
-.action-button.pin:hover:not(:disabled) {
-  border-color: #5919c7;
-  background: #5919c7;
-  color: #ffffff;
-}
-
-.action-button.unpin {
-  border-color: rgba(109, 35, 237, 0.45);
-  background: rgba(109, 35, 237, 0.08);
-  color: #6d23ed;
-}
-
-.action-button.unpin:hover:not(:disabled) {
-  border-color: #6d23ed;
-  background: #6d23ed;
-  color: #ffffff;
-}
-
-.action-button.delete {
-  border-color: rgba(255, 66, 66, 0.34);
-  color: #ff4242;
-}
-
-.action-button.delete:hover:not(:disabled) {
-  border-color: #ff4242;
-  background: #ff4242;
-  color: #ffffff;
-}
-
-.action-button:disabled,
-.select-all-button:disabled {
-  opacity: 0.55;
-  cursor: not-allowed;
-}
-
-.notice-list-header {
+.notice-page .notice-list-header {
   display: flex;
   align-items: flex-end;
   justify-content: space-between;
   gap: 16px;
-  margin: 22px 0 12px;
+  margin-bottom: 14px;
 }
 
-.notice-list-actions {
+.notice-page .notice-list-header h2 {
+  margin: 3px 0 0;
+  color: #0f0f10;
+  font-size: 17px;
+  font-weight: 700;
+  letter-spacing: -0.3px;
+}
+
+.notice-page .notice-list-actions {
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 8px;
   flex-wrap: wrap;
+  gap: 8px;
 }
 
-.notice-list-actions .select-all-button,
-.notice-list-actions .action-button {
-  width: auto;
-  min-width: 88px;
+.notice-page .select-all-button,
+.notice-page .action-button {
+  min-height: 34px;
+  min-width: 84px;
+  border-radius: 8px;
   padding: 0 14px;
-  border: 1px solid #e6e6e7;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
 }
 
-.notice-list-header h2 {
-  margin: 3px 0 0;
-  color: #0f0f10;
-  font-size: 22px;
-  font-weight: 800;
-  line-height: 1.25;
+.notice-page .select-all-button {
+  border: none;
+  background: transparent;
+  color: #747678;
 }
 
-.notice-grid {
+.notice-page .select-all-button:hover:not(:disabled) {
+  background: #f4f4f5;
+}
+
+.notice-page .action-button {
+  border: 1px solid #e4e4e7;
+  background: #ffffff;
+  color: #52525b;
+}
+
+.notice-page .action-button:hover:not(:disabled) {
+  background: #f4f4f5;
+}
+
+.notice-page .action-button.pin {
+  border-color: rgba(109, 35, 237, 0.24);
+  background: #ede9fe;
+  color: #6d23ed;
+}
+
+.notice-page .action-button.pin:hover:not(:disabled) {
+  border-color: rgba(109, 35, 237, 0.36);
+  background: rgba(109, 35, 237, 0.14);
+  color: #6d23ed;
+}
+
+.notice-page .action-button.unpin:hover:not(:disabled) {
+  border-color: #c9c9cc;
+}
+
+.notice-page .action-button.delete {
+  border-color: rgba(239, 68, 68, 0.32);
+  color: #ef4444;
+}
+
+.notice-page .action-button.delete:hover:not(:disabled) {
+  border-color: #ef4444;
+  background: rgba(239, 68, 68, 0.06);
+  color: #ef4444;
+}
+
+.notice-page .action-button:disabled,
+.notice-page .select-all-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.notice-page .notice-grid {
   display: grid;
   grid-template-columns: minmax(0, 1fr);
-  gap: 14px;
+  gap: 12px;
 }
 
-.notice-card {
-  min-height: 174px;
+.notice-page .notice-card {
+  position: relative;
   display: flex;
   flex-direction: column;
-  gap: 16px;
-  padding: 18px;
+  gap: 14px;
+  padding: 18px 20px;
+  border: 1px solid #e5e5e5;
+  border-radius: 12px;
+  background: #ffffff;
   cursor: pointer;
-  position: relative;
-  transition: border-color 0.18s ease, box-shadow 0.18s ease, transform 0.18s ease, background 0.18s ease;
+  transition: border-color 0.15s ease, background-color 0.15s ease;
 }
 
-.notice-card:hover {
-  transform: translateY(-1px);
-  border-color: rgba(109, 35, 237, 0.36);
-  box-shadow: 0 8px 24px rgba(109, 35, 237, 0.1);
+.notice-page .notice-card:hover {
+  border-color: #c9c9cc;
 }
 
-.notice-card.selected {
+.notice-page .notice-card.selected {
   border-color: #6d23ed;
-  background: #fbf9ff;
-  box-shadow: 0 8px 24px rgba(109, 35, 237, 0.14);
+  background: rgba(109, 35, 237, 0.04);
 }
 
-.notice-card.pinned {
-  border-top-color: rgba(109, 35, 237, 0.5);
+.notice-page .notice-card.pinned {
+  border-top-color: rgba(109, 35, 237, 0.45);
 }
 
-.notice-header,
-.notice-card-footer {
+.notice-page .notice-header,
+.notice-page .notice-card-footer {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
   gap: 12px;
 }
 
-.notice-badges {
+.notice-page .notice-badges {
   display: flex;
   align-items: center;
-  gap: 6px;
   flex-wrap: wrap;
+  gap: 6px;
 }
 
-.notice-pin-badge,
-.notice-category {
-  min-height: 24px;
+.notice-page .notice-pin-badge,
+.notice-page .notice-category {
+  min-height: 22px;
   display: inline-flex;
   align-items: center;
   gap: 4px;
   border-radius: 999px;
-  padding: 0 9px;
+  padding: 0 8px;
   font-size: 12px;
-  font-weight: 800;
+  font-weight: 600;
 }
 
-.notice-pin-badge {
-  background: #6d23ed;
-  color: #ffffff;
-  box-shadow: 0 6px 14px rgba(109, 35, 237, 0.18);
+.notice-page .notice-pin-badge {
+  background: rgba(109, 35, 237, 0.08);
+  color: #6d23ed;
+  font-weight: 700;
 }
 
-.notice-pin-badge-icon {
-  width: 13px;
-  height: 13px;
+.notice-page .notice-pin-badge-icon {
+  width: 12px;
+  height: 12px;
   flex-shrink: 0;
 }
 
-.notice-category {
-  background: #f5f5f5;
+.notice-page .notice-category {
+  background: #f4f4f5;
   color: #747678;
 }
 
-.notice-select {
+.notice-page .notice-select {
   width: 28px;
   height: 28px;
   display: grid;
   place-items: center;
   border-radius: 8px;
   cursor: pointer;
-  transition: background 0.2s ease;
+  transition: background-color 0.15s ease;
 }
 
-.notice-select:hover {
+.notice-page .notice-select:hover {
   background: rgba(109, 35, 237, 0.08);
 }
 
-.notice-checkbox {
+.notice-page .notice-checkbox {
   width: 16px;
   height: 16px;
   margin: 0;
@@ -371,63 +320,69 @@
   accent-color: #6d23ed;
 }
 
-.notice-title {
+.notice-page .notice-title {
   display: -webkit-box;
   margin: 0;
   overflow: hidden;
   color: #0f0f10;
-  font-size: 18px;
-  font-weight: 800;
-  line-height: 1.45;
+  font-size: 15px;
+  font-weight: 700;
+  line-height: 1.5;
+  letter-spacing: -0.2px;
   text-overflow: ellipsis;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
 }
 
-.notice-card-footer {
+.notice-page .notice-card-footer {
   margin-top: auto;
   align-items: flex-end;
   color: #747678;
-  font-size: 13px;
-  font-weight: 700;
+  font-size: 12px;
+  font-weight: 600;
 }
 
-.notice-author {
+.notice-page .notice-author {
   margin: 0;
-  color: #5d5f60;
+  color: #52525b;
+  font-size: 12px;
+  font-weight: 600;
 }
 
-.notice-date {
+.notice-page .notice-date {
   display: flex;
   flex-direction: column;
   align-items: flex-end;
   gap: 2px;
   margin: 0;
   color: #747678;
+  font-size: 12px;
+  font-weight: 600;
   white-space: nowrap;
 }
 
-.notice-date small {
-  color: #9e9e9f;
-  font-size: 12px;
+.notice-page .notice-date small {
+  color: #a1a1aa;
+  font-size: 11px;
   font-weight: 600;
 }
 
-.notice-empty-state {
+.notice-page .notice-empty-state {
   grid-column: 1 / -1;
-  min-height: 220px;
+  min-height: 200px;
   display: grid;
   place-items: center;
   border: 1px dashed #d8d2e7;
-  border-radius: 12px;
+  border-radius: 10px;
   background: #ffffff;
+  padding: 20px;
   color: #747678;
-  font-size: 14px;
-  font-weight: 700;
+  font-size: 13px;
+  font-weight: 600;
   text-align: center;
 }
 
-.sr-only {
+.notice-page .sr-only {
   position: absolute;
   width: 1px;
   height: 1px;
@@ -444,7 +399,7 @@
     padding: 28px 24px;
   }
 
-  .notice-toolbar {
+  .notice-page .notice-toolbar {
     align-items: stretch;
     flex-direction: column;
   }
@@ -453,34 +408,22 @@
     width: 100%;
     display: grid;
     grid-template-columns: repeat(5, minmax(0, 1fr));
-    flex: none;
     gap: 8px;
   }
 
-  .filter-button {
+  .notice-page .filter-button {
     width: 100%;
     min-height: 38px;
     padding: 0 10px;
   }
 
-  .selection-action-bar {
-    align-items: flex-start;
-    flex-direction: column;
-  }
-
-  .selection-actions {
-    width: 100%;
-    justify-content: flex-start;
-  }
-
-  .notice-summary {
+  .notice-page .notice-summary {
     width: 100%;
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
-    margin-left: auto;
   }
 
-  .notice-summary span {
+  .notice-page .notice-summary span {
     justify-content: center;
   }
 }
@@ -490,34 +433,28 @@
     padding: 22px 18px;
   }
 
-  .notice-page-header {
+  .notice-page .notice-page-header {
     align-items: stretch;
     flex-direction: column;
-    padding: 24px;
   }
 
-  .create-button {
+  .notice-page .create-button {
     width: 100%;
   }
 
-  .page-title {
-    font-size: 26px;
-  }
-
-  .notice-list-header {
+  .notice-page .notice-list-header {
     align-items: stretch;
     flex-direction: column;
   }
 
-  .notice-list-actions {
+  .notice-page .notice-list-actions {
     width: 100%;
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(96px, 1fr));
   }
 
-  .notice-list-actions .select-all-button,
-  .notice-list-actions .action-button,
-  .select-all-button {
+  .notice-page .notice-list-actions .select-all-button,
+  .notice-page .notice-list-actions .action-button {
     width: 100%;
   }
 }
@@ -527,15 +464,8 @@
     padding: 18px 14px;
   }
 
-  .notice-page-header,
-  .notice-toolbar,
-  .selection-action-bar {
-    padding: 18px;
-  }
-
-  .notice-toolbar {
-    gap: 12px;
-    padding: 14px;
+  .notice-page .page-title {
+    font-size: 22px;
   }
 
   .notice-page .filter-section {
@@ -547,42 +477,34 @@
     grid-column: 1 / -1;
   }
 
-  .filter-button {
+  .notice-page .filter-button {
     min-height: 40px;
     padding: 0 10px;
   }
 
-  .notice-summary {
-    margin-left: 0;
+  .notice-page .notice-summary {
     gap: 6px;
   }
 
-  .notice-summary span {
+  .notice-page .notice-summary span {
     justify-content: center;
     padding: 0 8px;
   }
 
-  .selection-actions {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 8px;
-  }
-
-  .action-button {
-    width: 100%;
-    padding: 0 10px;
-  }
-
-  .notice-grid {
+  .notice-page .notice-grid {
     grid-template-columns: 1fr;
   }
 
-  .notice-card-footer {
+  .notice-page .notice-card {
+    padding: 16px;
+  }
+
+  .notice-page .notice-card-footer {
     align-items: flex-start;
     flex-direction: column;
   }
 
-  .notice-date {
+  .notice-page .notice-date {
     align-items: flex-start;
   }
 }

--- a/src/styles/Notice.css
+++ b/src/styles/Notice.css
@@ -9,7 +9,8 @@
 .notice-page > .notice-page-header,
 .notice-page > .notice-toolbar,
 .notice-page > .notice-list-header,
-.notice-page > .notice-grid {
+.notice-page > .notice-grid,
+.notice-page > .notice-skeleton {
   width: min(1180px, 100%);
   margin-left: auto;
   margin-right: auto;

--- a/src/styles/NoticeCreateModal.css
+++ b/src/styles/NoticeCreateModal.css
@@ -6,7 +6,7 @@
   align-items: center;
   justify-content: center;
   padding: 24px;
-  background: rgba(15, 15, 16, 0.42);
+  background: rgba(15, 15, 16, 0.4);
 }
 
 .notice-modal-backdrop .notice-modal-container {
@@ -16,8 +16,8 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  border: 1px solid #e6e6e7;
-  border-radius: 12px;
+  border: 1px solid #e5e5e5;
+  border-radius: 16px;
   background: #ffffff;
   box-shadow: 0 18px 54px rgba(15, 15, 16, 0.18);
 }
@@ -28,39 +28,37 @@
   justify-content: space-between;
   gap: 16px;
   padding: 22px 24px;
-  border-bottom: 1px solid #e6e6e7;
-  background:
-    linear-gradient(90deg, rgba(109, 35, 237, 0.08), rgba(109, 35, 237, 0) 48%),
-    #ffffff;
+  border-bottom: 1px solid #ececef;
+  background: #ffffff;
 }
 
 .notice-modal-backdrop .modal-title {
   margin: 0;
   color: #0f0f10;
-  font-size: 22px;
+  font-size: 20px;
   font-weight: 800;
   line-height: 1.25;
-  letter-spacing: 0;
+  letter-spacing: -0.3px;
 }
 
 .notice-modal-backdrop .modal-close-button {
   width: 36px;
   height: 36px;
   flex-shrink: 0;
-  border: 1px solid #e6e6e7;
+  border: 1px solid #e4e4e7;
   border-radius: 8px;
   background: #ffffff;
-  color: #5d5f60;
+  color: #52525b;
   font-size: 18px;
-  font-weight: 800;
+  font-weight: 700;
+  line-height: 1;
   cursor: pointer;
-  transition: all 0.2s;
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
 }
 
 .notice-modal-backdrop .modal-close-button:hover:not(:disabled) {
-  border-color: #6d23ed;
-  color: #6d23ed;
-  background: rgba(109, 35, 237, 0.05);
+  border-color: #c9c9cc;
+  background: #f4f4f5;
 }
 
 .notice-modal-backdrop .modal-close-button:disabled {
@@ -72,7 +70,7 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 18px;
+  gap: 20px;
   overflow-y: auto;
   padding: 24px;
   scrollbar-gutter: stable;
@@ -85,39 +83,39 @@
 }
 
 .notice-modal-backdrop .form-label {
-  color: #0f0f10;
+  color: #3f3f46;
   font-size: 14px;
-  font-weight: 800;
+  font-weight: 700;
 }
 
 .notice-modal-backdrop .required {
-  color: #ff4242;
+  color: #ef4444;
 }
 
 .notice-modal-backdrop .form-input,
 .notice-modal-backdrop .form-textarea,
 .notice-modal-backdrop .markdown-preview {
   width: 100%;
-  border: 1px solid #e6e6e7;
-  border-radius: 12px;
+  border: 1px solid #e5e5e5;
+  border-radius: 10px;
   background: #ffffff;
   color: #0f0f10;
   font-family: 'Pretendard', -apple-system, BlinkMacSystemFont, system-ui, Roboto, sans-serif;
   font-size: 14px;
   font-weight: 500;
   outline: none;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
 .notice-modal-backdrop .form-input {
-  height: 48px;
-  padding: 0 16px;
+  height: 44px;
+  padding: 0 14px;
 }
 
 .notice-modal-backdrop .form-textarea,
 .notice-modal-backdrop .markdown-preview {
   min-height: 280px;
-  padding: 16px;
+  padding: 14px 16px;
   overflow-y: auto;
   line-height: 1.65;
   resize: vertical;
@@ -132,84 +130,84 @@
 
 .notice-modal-backdrop .form-input::placeholder,
 .notice-modal-backdrop .form-textarea::placeholder {
-  color: #9e9e9f;
+  color: #a1a1aa;
 }
 
-.content-header {
+.notice-modal-backdrop .content-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 16px;
 }
 
-.editor-controls {
+.notice-modal-backdrop .editor-controls {
   display: flex;
   align-items: center;
-  gap: 10px;
   flex-wrap: wrap;
   justify-content: flex-end;
+  gap: 8px;
 }
 
-.refine-button {
-  min-height: 36px;
+.notice-modal-backdrop .refine-button {
+  min-height: 34px;
   border: 1px solid #6d23ed;
   border-radius: 8px;
   background: #6d23ed;
   color: #ffffff;
   padding: 0 14px;
   font-size: 13px;
-  font-weight: 800;
+  font-weight: 600;
   cursor: pointer;
-  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
   white-space: nowrap;
+  transition: background-color 0.15s ease, border-color 0.15s ease;
 }
 
-.refine-button:hover:not(:disabled) {
+.notice-modal-backdrop .refine-button:hover:not(:disabled) {
   border-color: #5919c7;
   background: #5919c7;
-  box-shadow: 0 6px 16px rgba(109, 35, 237, 0.18);
 }
 
-.refine-button:disabled {
-  border-color: #e6e6e7;
-  background: #eff0f1;
-  color: #9e9e9f;
+.notice-modal-backdrop .refine-button:disabled {
+  border-color: #e4e4e7;
+  background: #f4f4f5;
+  color: #a1a1aa;
   cursor: not-allowed;
 }
 
-.editor-tabs {
+.notice-modal-backdrop .editor-tabs {
   display: flex;
   gap: 4px;
-  border: 1px solid #e6e6e7;
+  border: 1px solid #e4e4e7;
   border-radius: 8px;
-  background: #f5f5f5;
+  background: #f4f4f5;
   padding: 3px;
 }
 
-.tab-button {
+.notice-modal-backdrop .tab-button {
   min-height: 30px;
-  border: 0;
+  border: 1px solid transparent;
   border-radius: 6px;
   background: transparent;
-  color: #5d5f60;
+  color: #52525b;
   padding: 0 12px;
   font-size: 13px;
-  font-weight: 800;
+  font-weight: 600;
   cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease;
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
 }
 
-.tab-button:hover {
-  color: #6d23ed;
-}
-
-.tab-button.active {
+.notice-modal-backdrop .tab-button:hover:not(.active) {
   background: #ffffff;
   color: #6d23ed;
-  box-shadow: 0 1px 3px rgba(15, 15, 16, 0.08);
 }
 
-.input-footer {
+.notice-modal-backdrop .tab-button.active {
+  border-color: #e4e4e7;
+  background: #ffffff;
+  color: #6d23ed;
+}
+
+.notice-modal-backdrop .input-footer {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -217,68 +215,68 @@
   min-height: 18px;
 }
 
-.char-count {
+.notice-modal-backdrop .char-count {
   margin-left: auto;
-  color: #9e9e9f;
+  color: #a1a1aa;
   font-size: 12px;
-  font-weight: 700;
+  font-weight: 600;
   white-space: nowrap;
 }
 
-.error-text {
-  color: #ff4242;
+.notice-modal-backdrop .error-text {
+  color: #ef4444;
   font-size: 12px;
-  font-weight: 700;
+  font-weight: 600;
 }
 
-.markdown-preview {
+.notice-modal-backdrop .markdown-preview {
   color: #0f0f10;
 }
 
-.markdown-preview h1 {
+.notice-modal-backdrop .markdown-preview h1 {
   font-size: 24px;
   font-weight: 800;
   margin: 16px 0 12px;
-  border-bottom: 1px solid #e6e6e7;
+  border-bottom: 1px solid #ececef;
   padding-bottom: 8px;
 }
 
-.markdown-preview h2 {
+.notice-modal-backdrop .markdown-preview h2 {
   font-size: 20px;
   font-weight: 800;
   margin: 14px 0 10px;
-  border-bottom: 1px solid #e6e6e7;
+  border-bottom: 1px solid #ececef;
   padding-bottom: 6px;
 }
 
-.markdown-preview h3 {
+.notice-modal-backdrop .markdown-preview h3 {
   font-size: 18px;
   font-weight: 700;
   margin: 12px 0 8px;
 }
 
-.markdown-preview p {
+.notice-modal-backdrop .markdown-preview p {
   margin: 8px 0;
 }
 
-.markdown-preview ul,
-.markdown-preview ol {
+.notice-modal-backdrop .markdown-preview ul,
+.notice-modal-backdrop .markdown-preview ol {
   margin: 8px 0;
   padding-left: 24px;
 }
 
-.markdown-preview li {
+.notice-modal-backdrop .markdown-preview li {
   margin: 4px 0;
 }
 
-.markdown-preview a {
+.notice-modal-backdrop .markdown-preview a {
   color: #6d23ed;
   text-decoration: none;
   border-bottom: 1px solid rgba(109, 35, 237, 0.3);
 }
 
-.markdown-preview code {
-  background: #f5f5f5;
+.notice-modal-backdrop .markdown-preview code {
+  background: #f4f4f5;
   padding: 2px 6px;
   border-radius: 4px;
   color: #d63384;
@@ -286,57 +284,58 @@
   font-size: 13px;
 }
 
-.markdown-preview pre {
+.notice-modal-backdrop .markdown-preview pre {
   overflow-x: auto;
   margin: 12px 0;
   border-radius: 8px;
-  background: #f5f5f5;
+  background: #f4f4f5;
   padding: 12px;
 }
 
-.markdown-preview pre code {
+.notice-modal-backdrop .markdown-preview pre code {
   background: transparent;
   color: #0f0f10;
   padding: 0;
 }
 
-.markdown-preview blockquote {
+.notice-modal-backdrop .markdown-preview blockquote {
   margin: 12px 0;
   border-left: 4px solid #6d23ed;
-  color: #5d5f60;
+  color: #52525b;
   padding-left: 16px;
 }
 
-.markdown-preview table {
+.notice-modal-backdrop .markdown-preview table {
   width: 100%;
   margin: 12px 0;
   border-collapse: collapse;
 }
 
-.markdown-preview table th,
-.markdown-preview table td {
-  border: 1px solid #e6e6e7;
+.notice-modal-backdrop .markdown-preview table th,
+.notice-modal-backdrop .markdown-preview table td {
+  border: 1px solid #e5e5e5;
   padding: 8px 12px;
   text-align: left;
 }
 
-.markdown-preview table th {
-  background: #f5f5f5;
+.notice-modal-backdrop .markdown-preview table th {
+  background: #f4f4f5;
   font-weight: 700;
 }
 
-.markdown-preview img {
+.notice-modal-backdrop .markdown-preview img {
   max-width: 100%;
   margin: 12px 0;
   border-radius: 8px;
 }
 
-.preview-empty {
+.notice-modal-backdrop .preview-empty {
   display: grid;
   min-height: 220px;
   place-items: center;
-  color: #9e9e9f;
-  font-weight: 700;
+  color: #747678;
+  font-size: 13px;
+  font-weight: 600;
 }
 
 .notice-modal-backdrop .modal-actions {
@@ -344,31 +343,29 @@
   justify-content: flex-end;
   gap: 10px;
   margin-top: 4px;
-  padding-top: 20px;
-  border-top: 1px solid #e6e6e7;
+  padding-top: 18px;
+  border-top: 1px solid #ececef;
 }
 
 .notice-modal-backdrop .cancel-button,
 .notice-modal-backdrop .submit-button {
-  min-height: 44px;
+  min-height: 42px;
   border-radius: 8px;
   padding: 0 22px;
   font-size: 14px;
-  font-weight: 800;
+  font-weight: 700;
   cursor: pointer;
-  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
 }
 
 .notice-modal-backdrop .cancel-button {
-  border: 1px solid #e6e6e7;
+  border: 1px solid #e4e4e7;
   background: #ffffff;
-  color: #5d5f60;
+  color: #52525b;
 }
 
 .notice-modal-backdrop .cancel-button:hover:not(:disabled) {
-  border-color: #6d23ed;
-  color: #6d23ed;
-  background: rgba(109, 35, 237, 0.05);
+  background: #f4f4f5;
 }
 
 .notice-modal-backdrop .submit-button {
@@ -380,7 +377,6 @@
 .notice-modal-backdrop .submit-button:hover:not(:disabled) {
   border-color: #5919c7;
   background: #5919c7;
-  box-shadow: 0 6px 16px rgba(109, 35, 237, 0.18);
 }
 
 .notice-modal-backdrop .cancel-button:disabled,
@@ -404,12 +400,12 @@
     padding: 20px;
   }
 
-  .content-header {
+  .notice-modal-backdrop .content-header {
     align-items: stretch;
     flex-direction: column;
   }
 
-  .editor-controls {
+  .notice-modal-backdrop .editor-controls {
     justify-content: flex-start;
   }
 
@@ -434,17 +430,17 @@
     border-radius: 0;
   }
 
-  .editor-controls {
+  .notice-modal-backdrop .editor-controls {
     display: grid;
     grid-template-columns: 1fr;
   }
 
-  .editor-tabs,
-  .refine-button {
+  .notice-modal-backdrop .editor-tabs,
+  .notice-modal-backdrop .refine-button {
     width: 100%;
   }
 
-  .tab-button {
+  .notice-modal-backdrop .tab-button {
     flex: 1;
   }
 }

--- a/src/styles/PatchNote.css
+++ b/src/styles/PatchNote.css
@@ -1,4 +1,6 @@
-/* 패치노트 공개 페이지 스타일 - Qvick 디자인 시스템 */
+/* 패치노트 공개 페이지 스타일
+   - 대시보드/사이드바/탑바 톤의 디자인 토큰 적용 (배경 #fafafa, 카드 보더 중심, 그림자 없음)
+   - 모든 선택자는 .patchnote-page 하위로 스코핑하여 다른 페이지와의 충돌 방지 */
 
 .patchnote-page {
   min-height: 100vh;
@@ -7,145 +9,117 @@
   flex-direction: column;
 }
 
-.patchnote-loading {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  min-height: 100vh;
-  gap: 16px;
-}
-
-/* 스켈레톤 로딩 */
-.skeleton {
-  background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%);
+/* 로딩 스켈레톤 (페이지 스코프 내에서만 적용) */
+.patchnote-page .skeleton {
+  background: linear-gradient(90deg, #f1f1f3 25%, #e9e9ec 50%, #f1f1f3 75%);
   background-size: 200% 100%;
-  animation: skeleton-loading 1.5s infinite;
+  animation: pn-skeleton-loading 1.5s infinite ease-in-out;
   border-radius: 4px;
 }
 
-@keyframes skeleton-loading {
-  0% { background-position: 200% 0; }
-  100% { background-position: -200% 0; }
+@keyframes pn-skeleton-loading {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
 }
 
-.article-content-skeleton {
+.patchnote-page .article-content-skeleton {
   padding: 0;
 }
 
-.skeleton-line {
-  height: 16px;
+.patchnote-page .skeleton-line {
+  height: 14px;
   margin-bottom: 12px;
   border-radius: 4px;
 }
 
-.skeleton-line.title {
-  height: 24px;
+.patchnote-page .skeleton-line.title {
+  height: 22px;
   width: 60%;
   margin-bottom: 20px;
 }
 
-.skeleton-line.short {
+.patchnote-page .skeleton-line.short {
   width: 40%;
 }
 
-.skeleton-line.medium {
+.patchnote-page .skeleton-line.medium {
   width: 70%;
 }
 
-.skeleton-line.long {
+.patchnote-page .skeleton-line.long {
   width: 90%;
 }
 
-/* 사이드바 스켈레톤 아이템 */
-.version-item.skeleton-item {
+.patchnote-page .version-item.skeleton-item {
   cursor: default;
   pointer-events: none;
-  padding: 16px;
 }
 
-.version-item.skeleton-item:hover {
+.patchnote-page .version-item.skeleton-item:hover {
   background: transparent;
-  transform: none;
 }
 
-.loading-spinner {
-  width: 40px;
-  height: 40px;
-  border: 3px solid #e6e6e7;
-  border-top-color: #6d23ed;
-  border-radius: 50%;
-  animation: spin 1s linear infinite;
-}
-
-@keyframes spin {
-  to { transform: rotate(360deg); }
-}
-
-.patchnote-loading p {
-  font-size: 14px;
-  color: #747678;
-}
-
-/* 헤더 */
-.patchnote-header {
+/* 헤더 (탑바 톤: 밝은 배경 + 크롬 보더, 은은한 장식) */
+.patchnote-page .patchnote-header {
   position: relative;
-  padding: 60px 24px 80px;
-  background: linear-gradient(135deg, #0f0f10 0%, #1a1a2e 100%);
   overflow: hidden;
+  padding: 48px 24px 44px;
+  background: #ffffff;
+  border-bottom: 1px solid #ececef;
 }
 
-.header-content {
+.patchnote-page .header-content {
   position: relative;
   z-index: 1;
-  max-width: 1200px;
+  max-width: 1180px;
   margin: 0 auto;
   text-align: center;
 }
 
-.header-brand {
+.patchnote-page .header-brand {
   display: inline-flex;
   align-items: center;
-  gap: 12px;
-  margin-bottom: 24px;
-  cursor: pointer;
-  transition: opacity 0.2s;
+  gap: 10px;
+  margin-bottom: 20px;
 }
 
-.header-brand:hover {
-  opacity: 0.8;
+.patchnote-page .qvick-logo {
+  width: 40px;
+  height: 40px;
 }
 
-.qvick-logo {
-  width: 48px;
-  height: 48px;
+.patchnote-page .qvick-logo path:not([fill^='url']) {
+  fill: #0f0f10;
 }
 
-.qvick-logo path:not([fill^="url"]) {
-  fill: #fff;
-}
-
-.brand-text {
-  font-size: 28px;
-  font-weight: 700;
-  color: #fff;
-}
-
-.header-title {
-  font-size: 48px;
+.patchnote-page .brand-text {
+  font-size: 20px;
   font-weight: 800;
-  color: #fff;
-  margin: 0 0 12px;
-  letter-spacing: -0.02em;
+  letter-spacing: -0.3px;
+  color: #0f0f10;
 }
 
-.header-subtitle {
-  font-size: 18px;
-  color: rgba(255, 255, 255, 0.7);
+.patchnote-page .header-title {
+  margin: 0 0 8px;
+  font-size: 26px;
+  font-weight: 800;
+  letter-spacing: -0.3px;
+  color: #0f0f10;
+}
+
+.patchnote-page .header-subtitle {
   margin: 0;
+  font-size: 14px;
+  font-weight: 500;
+  color: #747678;
 }
 
-.header-decoration {
+/* 헤더 장식 (밝은 배경 위 은은한 브랜드 컬러 워시) */
+.patchnote-page .header-decoration {
   position: absolute;
   top: 0;
   left: 0;
@@ -154,496 +128,569 @@
   pointer-events: none;
 }
 
-.decoration-circle {
+.patchnote-page .decoration-circle {
   position: absolute;
   border-radius: 50%;
-  opacity: 0.1;
 }
 
-.circle-1 {
-  width: 400px;
-  height: 400px;
-  background: linear-gradient(135deg, #6d23ed, #1492fc);
-  top: -200px;
-  right: -100px;
+.patchnote-page .circle-1 {
+  width: 420px;
+  height: 420px;
+  top: -260px;
+  right: -120px;
+  background: radial-gradient(closest-side, rgba(109, 35, 237, 0.08), rgba(109, 35, 237, 0));
 }
 
-.circle-2 {
-  width: 300px;
-  height: 300px;
-  background: linear-gradient(135deg, #897eed, #6d23ed);
-  bottom: -150px;
-  left: -50px;
+.patchnote-page .circle-2 {
+  width: 320px;
+  height: 320px;
+  bottom: -200px;
+  left: -80px;
+  background: radial-gradient(closest-side, rgba(137, 126, 237, 0.07), rgba(137, 126, 237, 0));
 }
 
-.circle-3 {
-  width: 200px;
-  height: 200px;
-  background: linear-gradient(135deg, #1492fc, #6d23ed);
+.patchnote-page .circle-3 {
+  width: 240px;
+  height: 240px;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
+  background: radial-gradient(closest-side, rgba(20, 146, 252, 0.05), rgba(20, 146, 252, 0));
 }
 
 /* 컨테이너 */
-.patchnote-container {
+.patchnote-page .patchnote-container {
   flex: 1;
-  max-width: 1200px;
   width: 100%;
-  margin: -40px auto 0;
-  padding: 0 24px 60px;
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 32px 40px 64px;
   position: relative;
   z-index: 1;
 }
 
 /* 빈 상태 */
-.empty-state {
+.patchnote-page .patchnote-container .empty-state {
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 80px 24px;
-  background: #fff;
-  border-radius: 16px;
+  padding: 64px 32px;
+  background: #ffffff;
+  border: 1px dashed #d8d2e7;
+  border-radius: 10px;
   text-align: center;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
 }
 
-.empty-icon {
-  font-size: 64px;
-  margin-bottom: 24px;
+.patchnote-page .empty-icon {
+  font-size: 36px;
+  margin-bottom: 12px;
 }
 
-.empty-state h3 {
-  font-size: 20px;
-  font-weight: 600;
+.patchnote-page .empty-state h3 {
+  margin: 0 0 6px;
+  font-size: 15px;
+  font-weight: 700;
   color: #0f0f10;
-  margin: 0 0 8px;
 }
 
-.empty-state p {
-  font-size: 14px;
-  color: #747678;
+.patchnote-page .empty-state p {
   margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: #747678;
 }
 
 /* 레이아웃 */
-.patchnote-layout {
+.patchnote-page .patchnote-layout {
   display: grid;
-  grid-template-columns: 280px 1fr;
+  grid-template-columns: 280px minmax(0, 1fr);
+  align-items: start;
   gap: 24px;
 }
 
-/* 사이드바 */
-.patchnote-sidebar {
-  background: #fff;
-  border-radius: 16px;
-  padding: 24px;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+/* 버전 목록 사이드바 */
+.patchnote-page .patchnote-sidebar {
+  background: #ffffff;
+  border: 1px solid #e5e5e5;
+  border-radius: 12px;
+  padding: 16px;
   height: fit-content;
   position: sticky;
   top: 24px;
 }
 
-.sidebar-header {
+.patchnote-page .sidebar-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 20px;
-  padding-bottom: 16px;
-  border-bottom: 1px solid #e6e6e7;
+  gap: 8px;
+  margin-bottom: 12px;
+  padding: 2px 4px 12px;
+  border-bottom: 1px solid #ececef;
 }
 
-.sidebar-header h2 {
-  font-size: 16px;
+.patchnote-page .sidebar-header h2 {
+  margin: 0;
+  font-size: 17px;
   font-weight: 700;
   color: #0f0f10;
-  margin: 0;
 }
 
-.version-count {
-  font-size: 13px;
+.patchnote-page .version-count {
+  padding: 3px 9px;
+  background: #f4f4f5;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
   color: #747678;
-  background: #f3f4f6;
-  padding: 4px 10px;
-  border-radius: 12px;
 }
 
-.version-list {
+.patchnote-page .version-list {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 4px;
 }
 
-.version-item {
+.patchnote-page .version-item {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
   gap: 6px;
-  padding: 14px 16px;
-  background: #fafafa;
-  border: 2px solid transparent;
-  border-radius: 12px;
-  cursor: pointer;
-  transition: all 0.2s;
-  text-align: left;
   width: 100%;
+  padding: 11px 12px;
+  border: none;
+  border-radius: 10px;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+  font-family: inherit;
+  box-sizing: border-box;
+  transition: background-color 0.15s ease;
 }
 
-.version-item:hover {
-  background: #f3f4f6;
+.patchnote-page .version-item:hover {
+  background: #f4f4f5;
 }
 
-.version-item.active {
-  background: linear-gradient(135deg, rgba(109, 35, 237, 0.05), rgba(20, 146, 252, 0.05));
-  border-color: #6d23ed;
+.patchnote-page .version-item:focus-visible {
+  outline: 2px solid #6d23ed;
+  outline-offset: 2px;
 }
 
-.version-item-header {
+.patchnote-page .version-item.active {
+  background: #ede9fe;
+}
+
+.patchnote-page .version-item.active .version-number,
+.patchnote-page .version-item.active .version-item-title {
+  color: #6d23ed;
+}
+
+.patchnote-page .version-item.active .version-item-date {
+  color: rgba(109, 35, 237, 0.7);
+}
+
+.patchnote-page .version-item-header {
   display: flex;
   align-items: center;
   gap: 8px;
 }
 
-.version-number {
-  font-size: 14px;
-  font-weight: 700;
+.patchnote-page .version-number {
+  font-size: 12px;
+  font-weight: 800;
   color: #6d23ed;
+  white-space: nowrap;
 }
 
-.category-dot {
+.patchnote-page .category-dot {
   width: 8px;
   height: 8px;
+  flex-shrink: 0;
   border-radius: 50%;
 }
 
-.version-item-title {
-  font-size: 14px;
-  font-weight: 500;
-  color: #0f0f10;
+.patchnote-page .version-item-title {
   margin: 0;
-  line-height: 1.4;
+  font-size: 13px;
+  font-weight: 600;
+  color: #3f3f46;
+  line-height: 1.45;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
 }
 
-.version-item-date {
+.patchnote-page .version-item-date {
   font-size: 12px;
+  font-weight: 600;
   color: #747678;
 }
 
 /* 메인 컨텐츠 */
-.patchnote-main {
-  background: #fff;
-  border-radius: 16px;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+.patchnote-page .patchnote-main {
+  background: #ffffff;
+  border: 1px solid #e5e5e5;
+  border-radius: 12px;
   overflow: hidden;
 }
 
-.no-selection {
+.patchnote-page .patchnote-main .no-selection {
   display: flex;
   align-items: center;
   justify-content: center;
-  min-height: 400px;
+  min-height: 360px;
+  padding: 32px;
+  background: #ffffff;
+  border: 1px dashed #d8d2e7;
+  border-radius: 10px;
+  margin: 16px;
+}
+
+.patchnote-page .no-selection p {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
   color: #747678;
-  font-size: 16px;
 }
 
 /* 아티클 */
-.patchnote-article {
-  padding: 40px;
+.patchnote-page .patchnote-article {
+  padding: 24px;
 }
 
-.article-header {
-  margin-bottom: 32px;
-  padding-bottom: 24px;
-  border-bottom: 1px solid #e6e6e7;
+.patchnote-page .article-header {
+  margin-bottom: 24px;
+  padding-bottom: 20px;
+  border-bottom: 1px solid #ececef;
 }
 
-.article-meta {
+.patchnote-page .article-meta {
   display: flex;
-  align-items: center;
-  gap: 12px;
-  margin-bottom: 16px;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 14px;
 }
 
-.category-badge {
+/* 뱃지 공통 형태 (카테고리 색상은 인라인 토큰 유지) */
+.patchnote-page .category-badge,
+.patchnote-page .version-badge {
   display: inline-flex;
   align-items: center;
-  padding: 6px 14px;
-  border-radius: 8px;
-  font-size: 14px;
-  font-weight: 600;
-}
-
-.version-badge {
-  display: inline-flex;
-  align-items: center;
-  padding: 6px 14px;
-  background: #f3f4f6;
-  border-radius: 8px;
-  font-size: 14px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
   font-weight: 700;
-  color: #374151;
-}
-
-.article-title {
-  font-size: 36px;
-  font-weight: 800;
-  color: #0f0f10;
-  margin: 0 0 16px;
   line-height: 1.3;
-  letter-spacing: -0.02em;
+  white-space: nowrap;
 }
 
-.article-info {
+.patchnote-page .version-badge {
+  color: #52525b;
+  background: #f4f4f5;
+}
+
+.patchnote-page .article-title {
+  margin: 0 0 10px;
+  font-size: 24px;
+  font-weight: 800;
+  letter-spacing: -0.3px;
+  line-height: 1.35;
+  color: #0f0f10;
+}
+
+.patchnote-page .article-info {
   display: flex;
   align-items: center;
-  gap: 16px;
-  font-size: 14px;
+  font-size: 12px;
+  font-weight: 600;
   color: #747678;
 }
 
-.article-date::after {
+.patchnote-page .article-author::before {
   content: '·';
-  margin-left: 16px;
+  margin-right: 12px;
 }
 
-/* 아티클 컨텐츠 */
-.article-content {
-  font-size: 16px;
-  line-height: 1.8;
-  color: #374151;
+/* 마크다운 아티클 타이포그래피 */
+.patchnote-page .patchnote-article .article-content {
+  font-size: 15px;
+  font-weight: 500;
+  line-height: 1.7;
+  color: #3f3f46;
 }
 
-.article-content h1 {
-  font-size: 28px;
-  font-weight: 800;
-  color: #0f0f10;
-  margin: 16px 0 12px;
-  padding-bottom: 12px;
-  border-bottom: 2px solid #e6e6e7;
-}
-
-.article-content h1:first-child {
+.patchnote-page .article-content > :first-child {
   margin-top: 0;
 }
 
-.article-content h2 {
-  font-size: 22px;
+.patchnote-page .article-content > :last-child {
+  margin-bottom: 0;
+}
+
+.patchnote-page .article-content h1 {
+  margin: 28px 0 12px;
+  font-size: 24px;
+  font-weight: 800;
+  letter-spacing: -0.3px;
+  line-height: 1.35;
+  color: #0f0f10;
+}
+
+.patchnote-page .article-content h2 {
+  margin: 28px 0 12px;
+  font-size: 20px;
+  font-weight: 800;
+  letter-spacing: -0.3px;
+  line-height: 1.4;
+  color: #0f0f10;
+}
+
+.patchnote-page .article-content h3 {
+  margin: 20px 0 8px;
+  font-size: 17px;
   font-weight: 700;
   color: #0f0f10;
-  margin: 16px 0 10px;
 }
 
-.article-content h2:first-child {
-  margin-top: 0;
+.patchnote-page .article-content h4,
+.patchnote-page .article-content h5,
+.patchnote-page .article-content h6 {
+  margin: 16px 0 8px;
+  font-size: 15px;
+  font-weight: 700;
+  color: #3f3f46;
 }
 
-.article-content h3 {
-  font-size: 18px;
-  font-weight: 600;
-  color: #374151;
-  margin: 12px 0 8px;
+.patchnote-page .article-content p {
+  margin: 10px 0;
 }
 
-.article-content h3:first-child {
-  margin-top: 0;
+.patchnote-page .article-content ul,
+.patchnote-page .article-content ol {
+  margin: 10px 0;
+  padding-left: 22px;
 }
 
-.article-content p {
-  margin: 12px 0;
+.patchnote-page .article-content ul {
+  list-style-type: disc;
 }
 
-.article-content ul {
-  padding-left: 24px;
-  margin: 8px 0;
-}
-
-.article-content li {
+.patchnote-page .article-content li {
   margin: 4px 0;
-  position: relative;
+  line-height: 1.6;
 }
 
-.article-content li::marker {
+.patchnote-page .article-content li::marker {
   color: #6d23ed;
 }
 
-.article-content code {
-  padding: 3px 8px;
-  background: linear-gradient(135deg, rgba(109, 35, 237, 0.08), rgba(20, 146, 252, 0.08));
-  border-radius: 6px;
-  font-family: 'SF Mono', 'Menlo', 'Monaco', monospace;
-  font-size: 14px;
-  color: #6d23ed;
-}
-
-.article-content strong {
-  font-weight: 600;
+.patchnote-page .article-content strong {
+  font-weight: 700;
   color: #0f0f10;
 }
 
-.article-content a {
-  color: #1492fc;
+.patchnote-page .article-content a {
+  color: #6d23ed;
+  font-weight: 600;
   text-decoration: none;
-  font-weight: 500;
 }
 
-.article-content a:hover {
+.patchnote-page .article-content a:hover {
   text-decoration: underline;
 }
 
-/* 푸터 */
-.patchnote-footer {
-  background: #0f0f10;
-  padding: 40px 24px;
+.patchnote-page .article-content code {
+  padding: 2px 6px;
+  background: #f4f4f5;
+  border-radius: 6px;
+  font-family: 'SF Mono', 'Menlo', 'Monaco', 'Fira Code', monospace;
+  font-size: 13px;
+  color: #6d23ed;
 }
 
-.footer-content {
-  max-width: 1200px;
+.patchnote-page .article-content pre {
+  margin: 12px 0;
+  padding: 12px 16px;
+  background: #f4f4f5;
+  border-radius: 8px;
+  overflow-x: auto;
+}
+
+.patchnote-page .article-content pre code {
+  padding: 0;
+  background: transparent;
+  border-radius: 0;
+  color: #3f3f46;
+}
+
+.patchnote-page .article-content blockquote {
+  margin: 12px 0;
+  padding: 2px 0 2px 14px;
+  border-left: 3px solid #e5e5e5;
+  color: #747678;
+}
+
+.patchnote-page .article-content hr {
+  margin: 20px 0;
+  border: none;
+  border-top: 1px solid #ececef;
+}
+
+.patchnote-page .article-content table {
+  width: 100%;
+  margin: 12px 0;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.patchnote-page .article-content th,
+.patchnote-page .article-content td {
+  padding: 8px 12px;
+  border: 1px solid #ececef;
+  text-align: left;
+}
+
+.patchnote-page .article-content th {
+  background: #fafafa;
+  color: #0f0f10;
+  font-weight: 700;
+}
+
+/* 패치노트 이미지 */
+.patchnote-page .patchnote-image {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  margin: 16px 0;
+  border: 1px solid #ececef;
+  border-radius: 8px;
+}
+
+/* 푸터 (탑바 톤: 밝은 배경 + 크롬 보더) */
+.patchnote-page .patchnote-footer {
+  background: #ffffff;
+  border-top: 1px solid #ececef;
+  padding: 28px 40px;
+}
+
+.patchnote-page .footer-content {
+  max-width: 1180px;
   margin: 0 auto;
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 16px;
 }
 
-.footer-brand {
+.patchnote-page .footer-brand {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
 }
 
-.footer-brand .qvick-logo {
-  width: 32px;
-  height: 32px;
+.patchnote-page .footer-brand .qvick-logo {
+  width: 24px;
+  height: 24px;
 }
 
-.footer-brand span {
-  font-size: 18px;
-  font-weight: 700;
-  color: #fff;
+.patchnote-page .footer-brand span {
+  font-size: 15px;
+  font-weight: 800;
+  letter-spacing: -0.3px;
+  color: #0f0f10;
 }
 
-.footer-copyright {
-  font-size: 14px;
-  color: rgba(255, 255, 255, 0.5);
+.patchnote-page .footer-copyright {
   margin: 0;
+  font-size: 12px;
+  font-weight: 600;
+  color: #747678;
 }
 
 /* 반응형 */
 @media (max-width: 992px) {
-  .patchnote-layout {
+  .patchnote-page .patchnote-layout {
     grid-template-columns: 1fr;
   }
-  
-  .patchnote-sidebar {
+
+  .patchnote-page .patchnote-sidebar {
     position: static;
   }
-  
-  .version-list {
+
+  .patchnote-page .version-list {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-    gap: 12px;
+    gap: 8px;
   }
 }
 
 @media (max-width: 768px) {
-  .patchnote-header {
-    padding: 40px 16px 60px;
+  .patchnote-page .patchnote-header {
+    padding: 36px 16px 36px;
   }
-  
-  .header-title {
-    font-size: 32px;
+
+  .patchnote-page .patchnote-container {
+    padding: 24px 16px 48px;
   }
-  
-  .header-subtitle {
-    font-size: 16px;
+
+  .patchnote-page .patchnote-sidebar {
+    padding: 12px;
   }
-  
-  .patchnote-container {
-    padding: 0 16px 40px;
-    margin-top: -30px;
-  }
-  
-  .patchnote-sidebar {
-    padding: 16px;
-  }
-  
-  .version-list {
+
+  .patchnote-page .version-list {
     grid-template-columns: 1fr;
   }
-  
-  .patchnote-article {
-    padding: 24px;
+
+  .patchnote-page .patchnote-article {
+    padding: 20px;
   }
-  
-  .article-title {
-    font-size: 24px;
+
+  .patchnote-page .article-title {
+    font-size: 22px;
   }
-  
-  .article-info {
+
+  .patchnote-page .article-info {
     flex-direction: column;
     align-items: flex-start;
     gap: 4px;
   }
-  
-  .article-date::after {
+
+  .patchnote-page .article-author::before {
     display: none;
   }
-  
-  .footer-content {
+
+  .patchnote-page .patchnote-footer {
+    padding: 24px 16px;
+  }
+
+  .patchnote-page .footer-content {
     flex-direction: column;
-    gap: 16px;
     text-align: center;
   }
 }
 
 @media (max-width: 480px) {
-  .qvick-logo {
-    width: 36px;
-    height: 36px;
+  .patchnote-page .qvick-logo {
+    width: 32px;
+    height: 32px;
   }
-  
-  .brand-text {
-    font-size: 22px;
+
+  .patchnote-page .brand-text {
+    font-size: 18px;
   }
-  
-  .header-title {
-    font-size: 28px;
+
+  .patchnote-page .header-title {
+    font-size: 24px;
   }
-  
-  .article-meta {
-    flex-wrap: wrap;
+
+  .patchnote-page .patchnote-article {
+    padding: 16px;
   }
-}
 
-/* Visibility 배지 */
-.visibility-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 4px 10px;
-  border-radius: 6px;
-  font-size: 12px;
-  font-weight: 600;
-}
-
-.visibility-badge.teacher {
-  background: #fef3c7;
-  color: #d97706;
-}
-
-/* 패치노트 이미지 */
-.patchnote-image {
-  max-width: 100%;
-  height: auto;
-  border-radius: 12px;
-  margin: 20px 0;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
-}
-
-.article-content .patchnote-image {
-  display: block;
+  .patchnote-page .article-title {
+    font-size: 20px;
+  }
 }

--- a/src/styles/PhoneBox.css
+++ b/src/styles/PhoneBox.css
@@ -1,220 +1,222 @@
-/* Phone Box Page - Room.css 레이아웃을 재사용하고 제출함 전용 요소만 정의 */
-.phonebox-grid {
+/* Phone Box Page - Room.css 레이아웃을 재사용하고 제출함 전용 요소만 정의 (.phonebox-page 루트 스코핑) */
+
+/* 제출함 카드 */
+.phonebox-page .phonebox-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(272px, 1fr));
   gap: 12px;
 }
 
-.phonebox-card {
+.phonebox-page .phonebox-card {
   min-width: 0;
   display: flex;
   flex-direction: column;
   gap: 12px;
   padding: 18px;
-  border: 1px solid #e6e6e7;
-  border-radius: 8px;
-  background: #fafafa;
-  transition:
-    border-color 0.2s,
-    background-color 0.2s,
-    box-shadow 0.2s;
-}
-
-.phonebox-card:hover {
-  border-color: #6d23ed;
+  border: 1px solid #e5e5e5;
+  border-radius: 12px;
   background: #ffffff;
-  box-shadow: 0 8px 22px rgba(109, 35, 237, 0.1);
+  transition: border-color 0.15s ease;
 }
 
-.phonebox-card-head {
+.phonebox-page .phonebox-card:hover {
+  border-color: #c9c9cc;
+}
+
+.phonebox-page .phonebox-card-head {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 10px;
 }
 
-.phonebox-card-name {
+.phonebox-page .phonebox-card-name {
   min-width: 0;
   margin: 0;
   overflow: hidden;
   color: #0f0f10;
-  font-size: 16px;
-  font-weight: 800;
+  font-size: 15px;
+  font-weight: 700;
   line-height: 1.3;
+  letter-spacing: -0.2px;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.phonebox-gender-badge {
+.phonebox-page .phonebox-gender-badge {
   flex-shrink: 0;
-  padding: 4px 10px;
+  padding: 3px 10px;
   border: 1px solid transparent;
   border-radius: 999px;
-  font-size: 12px;
-  font-weight: 800;
+  font-size: 11px;
+  font-weight: 700;
   white-space: nowrap;
 }
 
-.phonebox-gender-badge.male {
+.phonebox-page .phonebox-gender-badge.male {
   border-color: rgba(37, 99, 235, 0.2);
   background: rgba(37, 99, 235, 0.08);
   color: #2563eb;
 }
 
-.phonebox-gender-badge.female {
+.phonebox-page .phonebox-gender-badge.female {
   border-color: rgba(219, 39, 119, 0.2);
   background: rgba(219, 39, 119, 0.08);
   color: #db2777;
 }
 
-.phonebox-gender-badge.all {
-  border-color: rgba(109, 35, 237, 0.2);
-  background: rgba(109, 35, 237, 0.08);
+.phonebox-page .phonebox-gender-badge.all {
+  border-color: rgba(109, 35, 237, 0.25);
+  background: #ede9fe;
   color: #6d23ed;
 }
 
-.phonebox-card-count {
+.phonebox-page .phonebox-card-count {
   margin: 0;
   color: #747678;
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 600;
 }
 
-.phonebox-card-count strong {
+.phonebox-page .phonebox-card-count strong {
   color: #0f0f10;
-  font-weight: 800;
+  font-weight: 700;
 }
 
-.phonebox-card-preview {
+.phonebox-page .phonebox-card-preview {
   min-height: 30px;
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
 }
 
-.phonebox-student-chip {
+.phonebox-page .phonebox-student-chip {
   padding: 4px 9px;
-  border: 1px solid #e6e6e7;
-  border-radius: 6px;
-  background: #ffffff;
-  color: #5d5f60;
+  border: 1px solid #e5e5e5;
+  border-radius: 8px;
+  background: #fafafa;
+  color: #52525b;
   font-size: 12px;
-  font-weight: 700;
-}
-
-.phonebox-student-chip.more {
-  border-style: dashed;
-  color: #9e9e9f;
-}
-
-.phonebox-empty-preview {
-  color: #b0b2b4;
-  font-size: 13px;
   font-weight: 600;
 }
 
-.phonebox-card-actions {
+.phonebox-page .phonebox-student-chip.more {
+  border-style: dashed;
+  border-color: #e4e4e7;
+  background: #ffffff;
+  color: #747678;
+}
+
+.phonebox-page .phonebox-empty-preview {
+  color: #a1a1aa;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.phonebox-page .phonebox-card-actions {
   display: flex;
   align-items: center;
   gap: 8px;
   margin-top: auto;
   padding-top: 12px;
-  border-top: 1px solid #e6e6e7;
+  border-top: 1px solid #f4f4f5;
 }
 
-.phonebox-manage-button {
+.phonebox-page .phonebox-manage-button {
   flex: 1;
-  min-height: 36px;
+  min-height: 34px;
   padding: 0 12px;
-  border: 1px solid #d7ccfb;
+  border: 1px solid #e4e4e7;
   border-radius: 8px;
   background: #ffffff;
-  color: #6d23ed;
+  color: #52525b;
   font-size: 13px;
-  font-weight: 700;
+  font-weight: 600;
   cursor: pointer;
   transition:
-    border-color 0.2s,
-    background-color 0.2s;
+    border-color 0.15s ease,
+    background-color 0.15s ease,
+    color 0.15s ease;
 }
 
-.phonebox-manage-button:hover {
-  border-color: #6d23ed;
-  background: rgba(109, 35, 237, 0.08);
+.phonebox-page .phonebox-manage-button:hover {
+  border-color: #d4d4d8;
+  background: #f4f4f5;
+  color: #3f3f46;
 }
 
-.phonebox-icon-button {
-  width: 36px;
-  height: 36px;
+.phonebox-page .phonebox-icon-button {
+  width: 34px;
+  height: 34px;
   flex-shrink: 0;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   padding: 0;
-  border: 1px solid #e6e6e7;
+  border: 1px solid #e4e4e7;
   border-radius: 8px;
   background: #ffffff;
-  color: #5d5f60;
+  color: #747678;
   cursor: pointer;
   transition:
-    border-color 0.2s,
-    background-color 0.2s,
-    color 0.2s;
+    border-color 0.15s ease,
+    background-color 0.15s ease,
+    color 0.15s ease;
 }
 
-.phonebox-icon-button:hover {
-  border-color: #6d23ed;
-  background: rgba(109, 35, 237, 0.05);
-  color: #6d23ed;
+.phonebox-page .phonebox-icon-button:hover {
+  border-color: #d4d4d8;
+  background: #f4f4f5;
+  color: #3f3f46;
 }
 
-.phonebox-icon-button.danger:hover {
-  border-color: #ff4242;
-  background: #ff4242;
-  color: #ffffff;
+.phonebox-page .phonebox-icon-button.danger:hover {
+  border-color: rgba(239, 68, 68, 0.4);
+  background: rgba(239, 68, 68, 0.08);
+  color: #ef4444;
 }
 
-.phonebox-action-icon {
+.phonebox-page .phonebox-action-icon {
   width: 16px;
   height: 16px;
 }
 
 /* 제출함 생성 모달 - 기숙사 선택 */
-.phonebox-gender-options {
+.phonebox-page .phonebox-gender-options {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 8px;
 }
 
-.phonebox-gender-option {
-  min-height: 46px;
+.phonebox-page .phonebox-gender-option {
+  min-height: 42px;
   padding: 0 14px;
-  border: 1px solid #e6e6e7;
+  border: 1px solid #e4e4e7;
   border-radius: 8px;
   background: #ffffff;
-  color: #5d5f60;
-  font-size: 14px;
-  font-weight: 700;
+  color: #52525b;
+  font-size: 13px;
+  font-weight: 600;
   cursor: pointer;
   transition:
-    border-color 0.2s,
-    background-color 0.2s,
-    color 0.2s,
-    opacity 0.2s;
+    border-color 0.15s ease,
+    background-color 0.15s ease,
+    color 0.15s ease,
+    opacity 0.15s ease;
 }
 
-.phonebox-gender-option:hover:not(:disabled) {
-  border-color: #6d23ed;
+.phonebox-page .phonebox-gender-option:hover:not(:disabled):not(.active) {
+  border-color: #d4d4d8;
+  background: #f4f4f5;
+}
+
+.phonebox-page .phonebox-gender-option.active {
+  border-color: rgba(109, 35, 237, 0.3);
+  background: #ede9fe;
   color: #6d23ed;
 }
 
-.phonebox-gender-option.active {
-  border-color: #6d23ed;
-  background: rgba(109, 35, 237, 0.08);
-  color: #6d23ed;
-}
-
-.phonebox-gender-option:disabled {
+.phonebox-page .phonebox-gender-option:disabled {
   opacity: 0.55;
   cursor: not-allowed;
 }
@@ -224,23 +226,23 @@
   width: min(640px, 100%);
 }
 
-.phonebox-modal-subtitle {
+.phonebox-page .phonebox-modal-subtitle {
   display: flex;
   align-items: center;
   gap: 8px;
   margin: 8px 0 0;
   color: #747678;
-  font-size: 13px;
-  font-weight: 700;
+  font-size: 12px;
+  font-weight: 600;
 }
 
-.phonebox-modal-form {
+.phonebox-page .phonebox-modal-form {
   display: flex;
   flex-direction: column;
   min-height: 0;
 }
 
-.phonebox-modal-body {
+.phonebox-page .phonebox-modal-body {
   display: flex;
   flex-direction: column;
   gap: 20px;
@@ -250,81 +252,85 @@
 
 .phonebox-page .phonebox-modal-actions {
   padding: 16px 24px;
-  border-top: 1px solid #e6e6e7;
+  border-top: 1px solid #f4f4f5;
   background: #ffffff;
 }
 
-.phonebox-page .phonebox-student-list {
+.room-modal-backdrop .phonebox-modal .phonebox-student-list {
   max-height: 232px;
 }
 
-.phonebox-page .sleepover-student-option.assigned:disabled {
-  border-style: dashed;
-  background: #f5f5f5;
-  color: #9e9e9f;
-  opacity: 1;
+/* 학생 관리 모달 요청 에러 배너 */
+.phonebox-page .phonebox-modal-body .sleepover-message.error {
+  margin-bottom: 0;
+  padding: 12px 16px;
+  border: 1px solid rgba(239, 68, 68, 0.28);
+  border-radius: 10px;
+  background: rgba(239, 68, 68, 0.08);
+  color: #b91c1c;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.5;
 }
 
-.phonebox-page .sleepover-student-option.assigned .sleepover-student-meta {
-  color: #6d23ed;
-}
-
-.phonebox-section-head {
+.phonebox-page .phonebox-section-head {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
 }
 
-.phonebox-assigned-row {
+.phonebox-page .phonebox-assigned-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
   padding: 10px 14px;
-  border: 1px solid #e6e6e7;
-  border-radius: 8px;
+  border: 1px solid #e5e5e5;
+  border-radius: 10px;
   background: #ffffff;
   color: #0f0f10;
 }
 
-.phonebox-assigned-meta {
+.phonebox-page .phonebox-assigned-meta {
   display: flex;
   align-items: center;
   gap: 10px;
 }
 
-.phonebox-remove-button {
-  border: 1px solid #ff4242;
+.phonebox-page .phonebox-remove-button {
+  padding: 5px 10px;
+  border: 1px solid rgba(239, 68, 68, 0.35);
+  border-radius: 8px;
   background: transparent;
-  color: #ff4242;
-  padding: 4px 10px;
-  border-radius: 4px;
-  font-size: 13px;
-  font-weight: 700;
+  color: #ef4444;
+  font-size: 12px;
+  font-weight: 600;
   cursor: pointer;
   transition:
-    background-color 0.2s,
-    color 0.2s,
-    opacity 0.2s;
+    background-color 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease,
+    opacity 0.15s ease;
 }
 
-.phonebox-remove-button:hover:not(:disabled) {
-  background: #ff4242;
+.phonebox-page .phonebox-remove-button:hover:not(:disabled) {
+  border-color: #ef4444;
+  background: #ef4444;
   color: #ffffff;
 }
 
-.phonebox-remove-button:disabled {
+.phonebox-page .phonebox-remove-button:disabled {
   opacity: 0.55;
   cursor: not-allowed;
 }
 
 @media (max-width: 640px) {
-  .phonebox-grid {
+  .phonebox-page .phonebox-grid {
     grid-template-columns: 1fr;
   }
 
-  .phonebox-modal-body {
+  .phonebox-page .phonebox-modal-body {
     padding-left: 18px;
     padding-right: 18px;
   }
@@ -335,7 +341,7 @@
     padding-right: 18px;
   }
 
-  .phonebox-assigned-row {
+  .phonebox-page .phonebox-assigned-row {
     align-items: flex-start;
     flex-direction: column;
   }

--- a/src/styles/Room.css
+++ b/src/styles/Room.css
@@ -1,157 +1,164 @@
-/* Room Page */
+/* Room Page - 방 관리 / 휴대폰 제출함 공통 레이아웃 (.room-page 루트 스코핑) */
 .room-page {
   min-height: calc(100vh - 60px);
+  padding: 32px 40px;
   background: #fafafa;
 }
 
-.room-container {
-  width: 100%;
-  max-width: 1400px;
-  margin: 0 auto;
-  padding: 32px;
-}
-
-.room-toolbar {
+.room-page .room-container {
+  width: min(1180px, 100%);
   display: flex;
   flex-direction: column;
-  gap: 20px;
-  margin-bottom: 18px;
-  padding: 24px;
-  border: 1px solid #e6e6e7;
-  border-radius: 8px;
+  gap: 32px;
+  margin: 0 auto;
+}
+
+/* Toolbar */
+.room-page .room-toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 20px;
+  border: 1px solid #e5e5e5;
+  border-radius: 12px;
   background: #ffffff;
 }
 
-.room-toolbar-main {
+.room-page .room-toolbar-main {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
   gap: 16px;
 }
 
-.room-eyebrow {
+.room-page .room-eyebrow {
   margin: 0 0 4px;
-  color: #6d23ed;
+  color: #747678;
   font-size: 12px;
-  font-weight: 800;
-  letter-spacing: 0;
+  font-weight: 600;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
 }
 
-.room-title {
+.room-page .room-title {
   margin: 0;
   color: #0f0f10;
-  font-size: 24px;
+  font-size: 26px;
   font-weight: 800;
   line-height: 1.25;
-  letter-spacing: 0;
+  letter-spacing: -0.3px;
 }
 
-.create-room-button {
-  min-height: 42px;
-  padding: 0 18px;
+.room-page .create-room-button {
+  min-height: 38px;
+  padding: 0 16px;
   border: none;
   border-radius: 8px;
   background: #6d23ed;
   color: #ffffff;
-  font-size: 14px;
-  font-weight: 700;
+  font-size: 13px;
+  font-weight: 600;
   cursor: pointer;
   transition:
-    background-color 0.2s,
-    transform 0.2s;
+    background-color 0.15s ease,
+    transform 0.15s ease;
   white-space: nowrap;
 }
 
-.create-room-button:hover {
-  background: #5919c7;
+.room-page .create-room-button:hover {
+  background: #5b1dc9;
 }
 
-.create-room-button:active {
+.room-page .create-room-button:active {
+  background: #4f19af;
   transform: translateY(1px);
 }
 
-.room-control-row {
+.room-page .room-control-row {
   display: grid;
   grid-template-columns: minmax(240px, 360px) 1fr;
   gap: 14px;
-  align-items: start;
+  align-items: center;
 }
 
-.room-search-box {
-  min-height: 42px;
+.room-page .room-search-box {
+  min-height: 38px;
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 0 14px;
-  border: 1px solid #e6e6e7;
+  padding: 0 12px;
+  border: 1px solid #e4e4e7;
   border-radius: 8px;
   background: #ffffff;
-  transition:
-    border-color 0.2s,
-    box-shadow 0.2s;
+  transition: border-color 0.15s ease;
 }
 
-.room-search-box:focus-within {
+.room-page .room-search-box:hover {
+  border-color: #d4d4d8;
+}
+
+.room-page .room-search-box:focus-within {
   border-color: #6d23ed;
-  box-shadow: 0 0 0 3px rgba(109, 35, 237, 0.1);
 }
 
-.room-search-icon {
-  width: 18px;
-  height: 18px;
-  color: #9e9e9f;
+.room-page .room-search-icon {
+  width: 16px;
+  height: 16px;
+  color: #a1a1aa;
   flex-shrink: 0;
 }
 
-.room-search-input {
+.room-page .room-search-input {
   width: 100%;
   min-width: 0;
   border: none;
   outline: none;
   background: transparent;
   color: #0f0f10;
-  font-size: 14px;
+  font-size: 13px;
+  font-weight: 600;
 }
 
-.room-search-input::placeholder {
-  color: #b0b2b4;
+.room-page .room-search-input::placeholder {
+  color: #a1a1aa;
+  font-weight: 500;
 }
 
-.room-floor-filters {
+.room-page .room-floor-filters {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
 }
 
-.floor-filter-button {
-  min-height: 42px;
+.room-page .floor-filter-button {
+  min-height: 38px;
   padding: 0 14px;
-  border: 1px solid #e6e6e7;
+  border: 1px solid #e4e4e7;
   border-radius: 8px;
   background: #ffffff;
-  color: #5d5f60;
+  color: #52525b;
   font-size: 13px;
-  font-weight: 700;
+  font-weight: 600;
   cursor: pointer;
   transition:
-    border-color 0.2s,
-    background-color 0.2s,
-    color 0.2s;
+    border-color 0.15s ease,
+    background-color 0.15s ease,
+    color 0.15s ease;
 }
 
-.floor-filter-button:hover {
-  border-color: #6d23ed;
+.room-page .floor-filter-button:hover:not(.active) {
+  border-color: #d4d4d8;
+  background: #f4f4f5;
+}
+
+.room-page .floor-filter-button.active {
+  border-color: rgba(109, 35, 237, 0.3);
+  background: #ede9fe;
   color: #6d23ed;
 }
 
-.floor-filter-button.active {
-  border-color: #6d23ed;
-  background: rgba(109, 35, 237, 0.08);
-  color: #6d23ed;
-}
-
-.selection-bar {
+/* Selection Bar */
+.room-page .selection-bar {
   position: sticky;
   top: 72px;
   z-index: 5;
@@ -159,385 +166,385 @@
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  margin-bottom: 18px;
   padding: 12px 16px;
-  border: 1px solid rgba(109, 35, 237, 0.2);
-  border-radius: 8px;
-  background: #f6f2ff;
-  color: #4a19a8;
-  font-size: 14px;
-  font-weight: 700;
-  box-shadow: 0 8px 24px rgba(15, 15, 16, 0.08);
+  border: 1px solid rgba(109, 35, 237, 0.25);
+  border-radius: 10px;
+  background: #ede9fe;
+  color: #6d23ed;
+  font-size: 13px;
+  font-weight: 600;
 }
 
-.selection-actions {
+.room-page .selection-actions {
   display: flex;
   gap: 8px;
 }
 
-.clear-selection-button,
-.delete-selected-button,
-.select-all-button {
+.room-page .clear-selection-button,
+.room-page .delete-selected-button,
+.room-page .select-all-button {
+  min-height: 32px;
+  padding: 0 12px;
+  border: none;
   border-radius: 8px;
   font-size: 13px;
-  font-weight: 700;
+  font-weight: 600;
   cursor: pointer;
   transition:
-    background-color 0.2s,
-    border-color 0.2s,
-    color 0.2s,
-    opacity 0.2s;
+    background-color 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease,
+    opacity 0.15s ease;
 }
 
-.clear-selection-button {
-  padding: 8px 12px;
-  border: 1px solid rgba(109, 35, 237, 0.24);
+.room-page .clear-selection-button {
+  border: 1px solid #e4e4e7;
   background: #ffffff;
-  color: #6d23ed;
+  color: #52525b;
 }
 
-.delete-selected-button {
-  padding: 8px 12px;
-  border: 1px solid #ff4242;
-  background: #ff4242;
+.room-page .clear-selection-button:hover:not(:disabled) {
+  border-color: #d4d4d8;
+  background: #f4f4f5;
+}
+
+.room-page .delete-selected-button {
+  border: 1px solid rgba(239, 68, 68, 0.4);
+  background: #ffffff;
+  color: #ef4444;
+}
+
+.room-page .delete-selected-button:hover:not(:disabled) {
+  border-color: #ef4444;
+  background: #ef4444;
   color: #ffffff;
 }
 
-.clear-selection-button:hover:not(:disabled) {
-  border-color: #6d23ed;
+.room-page .select-all-button {
+  min-height: 34px;
+  background: transparent;
+  color: #747678;
 }
 
-.delete-selected-button:hover:not(:disabled) {
-  background: #e63939;
-  border-color: #e63939;
+.room-page .select-all-button:hover:not(:disabled) {
+  background: #f4f4f5;
+  color: #3f3f46;
 }
 
-.clear-selection-button:disabled,
-.delete-selected-button:disabled,
-.select-all-button:disabled {
+.room-page .clear-selection-button:disabled,
+.room-page .delete-selected-button:disabled,
+.room-page .select-all-button:disabled {
   opacity: 0.55;
   cursor: not-allowed;
 }
 
-.room-loading,
-.room-empty-state,
-.room-error-banner {
-  border-radius: 8px;
-  background: #ffffff;
-}
-
-.room-loading {
+/* Loading / Empty / Error */
+.room-page .room-loading {
   padding: 64px 20px;
-  text-align: center;
+  border: 1px solid #ececef;
+  border-radius: 10px;
+  background: #ffffff;
   color: #747678;
   font-size: 14px;
+  font-weight: 600;
+  text-align: center;
 }
 
-.room-empty-state {
+.room-page .room-empty-state {
   min-height: 220px;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 8px;
+  gap: 6px;
   padding: 48px 20px;
-  border: 1px dashed #d0d0d0;
+  border: 1px dashed #d8d2e7;
+  border-radius: 10px;
+  background: #ffffff;
   text-align: center;
 }
 
-.room-empty-state strong {
+.room-page .room-empty-state strong {
   color: #0f0f10;
-  font-size: 16px;
-  font-weight: 800;
-}
-
-.room-empty-state span {
-  color: #747678;
-  font-size: 14px;
-}
-
-.room-error-banner {
-  margin-bottom: 18px;
-  padding: 12px 14px;
-  border: 1px solid rgba(255, 66, 66, 0.22);
-  color: #c92a2a;
-  font-size: 14px;
+  font-size: 15px;
   font-weight: 700;
 }
 
-/* Floor Sections */
-.floor-sections {
-  display: flex;
-  flex-direction: column;
-  gap: 18px;
+.room-page .room-empty-state span {
+  color: #747678;
+  font-size: 13px;
+  font-weight: 600;
 }
 
-.floor-section {
+.room-page .room-error-banner {
+  padding: 12px 16px;
+  border: 1px solid rgba(239, 68, 68, 0.35);
+  border-radius: 10px;
+  background: rgba(239, 68, 68, 0.08);
+  color: #dc2626;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+/* Floor Sections */
+.room-page .floor-sections {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.room-page .floor-section {
   padding: 20px;
-  border: 1px solid #e6e6e7;
-  border-radius: 8px;
+  border: 1px solid #e5e5e5;
+  border-radius: 12px;
   background: #ffffff;
 }
 
-.floor-header {
+.room-page .floor-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 16px;
   margin-bottom: 16px;
   padding-bottom: 14px;
-  border-bottom: 1px solid #e6e6e7;
+  border-bottom: 1px solid #ececef;
 }
 
-.floor-title {
+.room-page .floor-title {
   margin: 0;
   color: #0f0f10;
-  font-size: 18px;
-  font-weight: 800;
+  font-size: 17px;
+  font-weight: 700;
   line-height: 1.3;
+  letter-spacing: -0.3px;
 }
 
-.floor-count {
+.room-page .floor-count {
   margin: 2px 0 0;
   color: #747678;
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 600;
 }
 
-.select-all-button {
-  min-height: 36px;
-  padding: 0 12px;
-  border: 1px solid #d7ccfb;
-  background: #ffffff;
-  color: #6d23ed;
-}
-
-.select-all-button:hover {
-  border-color: #6d23ed;
-  background: rgba(109, 35, 237, 0.08);
-}
-
 /* Room Grid */
-.room-grid {
+.room-page .room-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(156px, 1fr));
   gap: 12px;
 }
 
-.room-card {
+.room-page .room-card {
   min-width: 0;
-  min-height: 76px;
+  min-height: 72px;
   display: grid;
-  grid-template-columns: 22px minmax(0, 1fr) auto;
+  grid-template-columns: 20px minmax(0, 1fr) auto;
   align-items: center;
   gap: 12px;
-  padding: 14px;
-  border: 1px solid #e6e6e7;
-  border-radius: 8px;
-  background: #fafafa;
+  padding: 14px 16px;
+  border: 1px solid #e5e5e5;
+  border-radius: 12px;
+  background: #ffffff;
   color: #0f0f10;
   text-align: left;
   cursor: pointer;
   user-select: none;
-  transition:
-    border-color 0.2s,
-    background-color 0.2s,
-    box-shadow 0.2s;
+  transition: border-color 0.15s ease;
 }
 
-.room-card:hover {
-  border-color: #6d23ed;
-  background: #ffffff;
-  box-shadow: 0 8px 22px rgba(109, 35, 237, 0.1);
+.room-page .room-card:hover {
+  border-color: #c9c9cc;
 }
 
-.room-card:focus-visible {
-  outline: 3px solid rgba(109, 35, 237, 0.22);
+.room-page .room-card:focus-visible {
+  outline: 2px solid rgba(109, 35, 237, 0.45);
   outline-offset: 2px;
 }
 
-.room-card.selected {
+.room-page .room-card.selected {
   border-color: #6d23ed;
-  background: #f8f5ff;
-  box-shadow: inset 0 0 0 1px #6d23ed;
 }
 
-.room-checkbox {
-  width: 22px;
-  height: 22px;
+.room-page .room-checkbox {
+  width: 20px;
+  height: 20px;
   margin: 0;
   appearance: none;
-  border: 2px solid #cfd0d2;
+  border: 1.5px solid #d4d4d8;
   border-radius: 6px;
   background: #ffffff;
   cursor: pointer;
   flex-shrink: 0;
   position: relative;
   transition:
-    background-color 0.2s,
-    border-color 0.2s,
-    box-shadow 0.2s;
+    background-color 0.15s ease,
+    border-color 0.15s ease;
 }
 
-.room-checkbox:checked {
+.room-page .room-checkbox:checked {
   border-color: #6d23ed;
   background: #6d23ed;
-  box-shadow: 0 0 0 3px rgba(109, 35, 237, 0.12);
 }
 
-.room-checkbox:checked::after {
+.room-page .room-checkbox:checked::after {
   content: '';
   position: absolute;
-  left: 6px;
-  top: 2px;
-  width: 5px;
-  height: 10px;
+  left: 5px;
+  top: 1px;
+  width: 4.5px;
+  height: 9px;
   border: solid #ffffff;
-  border-width: 0 2.5px 2.5px 0;
+  border-width: 0 2px 2px 0;
   transform: rotate(45deg);
 }
 
-.room-checkbox:focus-visible {
-  outline: 3px solid rgba(109, 35, 237, 0.22);
+.room-page .room-checkbox:focus-visible {
+  outline: 2px solid rgba(109, 35, 237, 0.45);
   outline-offset: 2px;
 }
 
-.room-name {
+.room-page .room-name {
   min-width: 0;
   overflow: hidden;
   color: #0f0f10;
-  font-size: 16px;
-  font-weight: 800;
+  font-size: 15px;
+  font-weight: 700;
   line-height: 1.2;
+  letter-spacing: -0.2px;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.room-card-actions {
+.room-page .room-card-actions {
   display: flex;
   align-items: center;
   justify-content: flex-end;
 }
 
-.delete-room-button {
+.room-page .delete-room-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: 30px;
+  min-height: 28px;
   padding: 0 10px;
-  border: 1px solid rgba(255, 66, 66, 0.3);
+  border: 1px solid rgba(239, 68, 68, 0.35);
   border-radius: 8px;
   background: #ffffff;
-  color: #ff4242;
+  color: #ef4444;
   font-size: 12px;
-  font-weight: 800;
+  font-weight: 600;
   cursor: pointer;
   transition:
-    background-color 0.2s,
-    border-color 0.2s,
-    color 0.2s;
+    background-color 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease;
 }
 
-.delete-room-button:hover,
-.delete-room-button:focus-visible {
-  border-color: #ff4242;
-  background: #ff4242;
+.room-page .delete-room-button:hover,
+.room-page .delete-room-button:focus-visible {
+  border-color: #ef4444;
+  background: #ef4444;
   color: #ffffff;
   outline: none;
 }
 
+/* 반응형 */
 @media (max-width: 900px) {
-  .room-container {
-    padding: 24px 18px;
+  .room-page {
+    padding: 24px 20px;
   }
 
-  .room-control-row {
+  .room-page .room-container {
+    gap: 24px;
+  }
+
+  .room-page .room-control-row {
     grid-template-columns: 1fr;
   }
 }
 
 @media (max-width: 640px) {
-  .room-container {
-    padding: 18px 12px;
+  .room-page {
+    padding: 20px 14px;
   }
 
-  .room-toolbar {
+  .room-page .room-container {
+    gap: 20px;
+  }
+
+  .room-page .room-toolbar {
     padding: 18px;
   }
 
-  .room-toolbar-main {
+  .room-page .room-title {
+    font-size: 22px;
+  }
+
+  .room-page .room-toolbar-main {
     flex-direction: column;
   }
 
-  .create-room-button {
+  .room-page .create-room-button {
     width: 100%;
   }
 
-  .room-floor-filters {
+  .room-page .room-floor-filters {
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
-  .floor-filter-button {
+  .room-page .floor-filter-button {
     padding: 0 8px;
   }
 
-  .selection-bar {
+  .room-page .selection-bar {
     position: static;
     align-items: stretch;
     flex-direction: column;
   }
 
-  .selection-actions {
+  .room-page .selection-actions {
     display: grid;
     grid-template-columns: 1fr 1fr;
   }
 
-  .clear-selection-button,
-  .delete-selected-button {
+  .room-page .clear-selection-button,
+  .room-page .delete-selected-button {
     width: 100%;
   }
 
-  .floor-section {
+  .room-page .floor-section {
     padding: 16px;
   }
 
-  .floor-header {
+  .room-page .floor-header {
     display: grid;
     grid-template-columns: minmax(0, 1fr) 112px;
     gap: 12px;
     align-items: center;
   }
 
-  .floor-title {
-    font-size: 17px;
-  }
-
-  .floor-count {
+  .room-page .floor-count {
     white-space: nowrap;
   }
 
-  .select-all-button {
+  .room-page .select-all-button {
     width: 112px;
-    min-height: 38px;
-    padding: 0 10px;
     justify-self: end;
   }
 
-  .room-grid {
+  .room-page .room-grid {
     grid-template-columns: repeat(auto-fill, minmax(132px, 1fr));
   }
 
-  .room-card {
-    grid-template-columns: 22px minmax(0, 1fr);
+  .room-page .room-card {
+    grid-template-columns: 20px minmax(0, 1fr);
   }
 
-  .room-card-actions {
+  .room-page .room-card-actions {
     grid-column: 1 / -1;
   }
 
-  .delete-room-button {
+  .room-page .delete-room-button {
     width: 100%;
   }
-
 }

--- a/src/styles/RoomModal.css
+++ b/src/styles/RoomModal.css
@@ -1,5 +1,5 @@
 /* Room Modal - 방 추가 / 제출함 모달 공용 (모달 자체 스코핑, ConfirmationModal 패턴 기준) */
-.room-modal-backdrop .room-modal-backdrop {
+.room-modal-backdrop {
   position: fixed;
   inset: 0;
   z-index: 1100;
@@ -220,17 +220,17 @@
 }
 
 @media (max-width: 640px) {
-.room-modal-backdrop {
+  .room-modal-backdrop {
     align-items: flex-end;
     padding: 12px;
   }
 
-.room-modal-backdrop .room-modal {
+  .room-modal-backdrop .room-modal {
     width: 100%;
   }
 
-.room-modal-backdrop .room-modal-header,
-.room-modal-backdrop .room-modal-form {
+  .room-modal-backdrop .room-modal-header,
+  .room-modal-backdrop .room-modal-form {
     padding-left: 18px;
     padding-right: 18px;
   }

--- a/src/styles/RoomModal.css
+++ b/src/styles/RoomModal.css
@@ -1,5 +1,5 @@
-/* Room Modal */
-.room-modal-backdrop {
+/* Room Modal - 방 추가 / 제출함 모달 공용 (모달 자체 스코핑, ConfirmationModal 패턴 기준) */
+.room-modal-backdrop .room-modal-backdrop {
   position: fixed;
   inset: 0;
   z-index: 1100;
@@ -7,225 +7,334 @@
   align-items: center;
   justify-content: center;
   padding: 24px;
-  background: rgba(15, 15, 16, 0.42);
+  background: rgba(15, 15, 16, 0.4);
 }
 
-.room-modal {
+.room-modal-backdrop .room-modal {
   width: min(520px, 100%);
   max-height: min(90vh, 760px);
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  border: 1px solid #e6e6e7;
-  border-radius: 12px;
+  border: 1px solid #ececef;
+  border-radius: 16px;
   background: #ffffff;
   box-shadow: 0 18px 54px rgba(15, 15, 16, 0.18);
 }
 
-.room-modal-header {
+.room-modal-backdrop .room-modal-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 16px;
-  padding: 22px 24px;
-  border-bottom: 1px solid #e6e6e7;
+  padding: 20px 24px;
+  border-bottom: 1px solid #ececef;
 }
 
-.room-modal-eyebrow {
+.room-modal-backdrop .room-modal-eyebrow {
   margin: 0 0 4px;
   color: #6d23ed;
   font-size: 12px;
-  font-weight: 800;
-  letter-spacing: 0;
+  font-weight: 700;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
 }
 
-.room-modal-title {
+.room-modal-backdrop .room-modal-title {
   margin: 0;
   color: #0f0f10;
-  font-size: 22px;
+  font-size: 20px;
   font-weight: 800;
   line-height: 1.25;
+  letter-spacing: -0.3px;
 }
 
-.room-modal-close-button {
-  width: 36px;
-  height: 36px;
+.room-modal-backdrop .room-modal-close-button {
+  width: 34px;
+  height: 34px;
   flex-shrink: 0;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   padding: 0;
-  border: 1px solid #e6e6e7;
+  border: 1px solid #e4e4e7;
   border-radius: 8px;
   background: #ffffff;
-  color: #5d5f60;
-  font-size: 18px;
-  font-weight: 800;
+  color: #747678;
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 1;
   cursor: pointer;
   transition:
-    border-color 0.2s,
-    color 0.2s,
-    background-color 0.2s;
+    border-color 0.15s ease,
+    color 0.15s ease,
+    background-color 0.15s ease;
 }
 
-.room-modal-close-button:hover:not(:disabled) {
-  border-color: #6d23ed;
-  color: #6d23ed;
-  background: rgba(109, 35, 237, 0.05);
+.room-modal-backdrop .room-modal-close-button:hover:not(:disabled) {
+  border-color: #d4d4d8;
+  background: #f4f4f5;
+  color: #3f3f46;
 }
 
-.room-modal-close-button:disabled {
+.room-modal-backdrop .room-modal-close-button:disabled {
   opacity: 0.55;
   cursor: not-allowed;
 }
 
-.room-modal-form {
+/* Form */
+.room-modal-backdrop .room-modal-form {
   display: flex;
   flex-direction: column;
   gap: 20px;
   padding: 24px;
 }
 
-.room-form-group {
+.room-modal-backdrop .room-form-group {
   display: flex;
   flex-direction: column;
   gap: 8px;
 }
 
-.room-form-label {
-  color: #0f0f10;
+.room-modal-backdrop .room-form-label {
+  color: #3f3f46;
   font-size: 14px;
   font-weight: 700;
 }
 
-.required {
-  color: #ff4242;
+.room-modal-backdrop .required {
+  color: #ef4444;
 }
 
-.room-form-input {
+.room-modal-backdrop .room-form-input {
   width: 100%;
-  min-height: 46px;
-  padding: 0 14px;
-  border: 1px solid #e6e6e7;
+  min-height: 42px;
+  padding: 0 12px;
+  border: 1px solid #e4e4e7;
   border-radius: 8px;
   background: #ffffff;
   color: #0f0f10;
-  font-size: 15px;
+  font-size: 14px;
   outline: none;
   transition:
-    border-color 0.2s,
-    box-shadow 0.2s;
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
 }
 
-.room-form-input:focus {
+.room-modal-backdrop .room-form-input:hover:not(:disabled) {
+  border-color: #d4d4d8;
+}
+
+.room-modal-backdrop .room-form-input:focus {
   border-color: #6d23ed;
   box-shadow: 0 0 0 3px rgba(109, 35, 237, 0.1);
 }
 
-.room-form-input::placeholder {
-  color: #b0b2b4;
+.room-modal-backdrop .room-form-input::placeholder {
+  color: #a1a1aa;
+  font-weight: 500;
 }
 
-.input-helper {
+.room-modal-backdrop .input-helper {
   margin: 0;
   color: #747678;
   font-size: 13px;
+  font-weight: 500;
   line-height: 1.5;
 }
 
-.input-footer {
-  min-height: 20px;
+.room-modal-backdrop .input-footer {
+  min-height: 18px;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
 }
 
-.error-text {
-  color: #ff4242;
-  font-size: 13px;
-  font-weight: 700;
-}
-
-.input-example,
-.char-count {
-  color: #9e9e9f;
+.room-modal-backdrop .error-text {
+  color: #dc2626;
   font-size: 12px;
   font-weight: 600;
 }
 
-.char-count {
+.room-modal-backdrop .input-example,
+.room-modal-backdrop .char-count {
+  color: #747678;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.room-modal-backdrop .char-count {
   flex-shrink: 0;
 }
 
-.room-modal-actions {
+/* Actions */
+.room-modal-backdrop .room-modal-actions {
   display: flex;
   justify-content: flex-end;
   gap: 10px;
   padding-top: 4px;
 }
 
-.room-cancel-button,
-.room-submit-button {
+.room-modal-backdrop .room-cancel-button,
+.room-modal-backdrop .room-submit-button {
   min-width: 92px;
-  min-height: 42px;
+  min-height: 40px;
+  padding: 0 16px;
   border: none;
   border-radius: 8px;
-  font-size: 14px;
-  font-weight: 700;
+  font-size: 13px;
+  font-weight: 600;
   cursor: pointer;
   transition:
-    background-color 0.2s,
-    opacity 0.2s;
+    background-color 0.15s ease,
+    opacity 0.15s ease;
 }
 
-.room-cancel-button {
-  background: #f5f5f5;
-  color: #0f0f10;
+.room-modal-backdrop .room-cancel-button {
+  background: #f4f4f5;
+  color: #52525b;
 }
 
-.room-cancel-button:hover:not(:disabled) {
-  background: #e6e6e7;
+.room-modal-backdrop .room-cancel-button:hover:not(:disabled) {
+  background: #e4e4e7;
 }
 
-.room-submit-button {
+.room-modal-backdrop .room-submit-button {
   background: #6d23ed;
   color: #ffffff;
 }
 
-.room-submit-button:hover:not(:disabled) {
-  background: #5919c7;
+.room-modal-backdrop .room-submit-button:hover:not(:disabled) {
+  background: #5b1dc9;
 }
 
-.room-cancel-button:disabled,
-.room-submit-button:disabled {
+.room-modal-backdrop .room-submit-button:active:not(:disabled) {
+  background: #4f19af;
+}
+
+.room-modal-backdrop .room-cancel-button:disabled,
+.room-modal-backdrop .room-submit-button:disabled {
   opacity: 0.55;
   cursor: not-allowed;
 }
 
 @media (max-width: 640px) {
-  .room-modal-backdrop {
+.room-modal-backdrop {
     align-items: flex-end;
     padding: 12px;
   }
 
-  .room-modal {
+.room-modal-backdrop .room-modal {
     width: 100%;
   }
 
-  .room-modal-header,
-  .room-modal-form {
+.room-modal-backdrop .room-modal-header,
+.room-modal-backdrop .room-modal-form {
     padding-left: 18px;
     padding-right: 18px;
   }
 
-  .room-modal-actions {
+.room-modal-backdrop .room-modal-actions {
     flex-direction: column-reverse;
   }
 
-  .room-cancel-button,
-  .room-submit-button {
+.room-modal-backdrop .room-cancel-button,
+.room-modal-backdrop .room-submit-button {
     width: 100%;
+  }
+}
+
+/* 학생 검색 목록 (외박자 추가/제출함 학생 관리/자치위원 추가 모달 공용) */
+.room-modal-backdrop .sleepover-modal {
+  width: min(620px, 100%);
+}
+
+.room-modal-backdrop .sleepover-student-list {
+  max-height: 260px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 4px 2px;
+}
+
+.room-modal-backdrop .sleepover-student-option {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 11px 14px;
+  border: 1px solid #e4e4e7;
+  border-radius: 10px;
+  background: #ffffff;
+  color: #0f0f10;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color 0.15s ease,
+    background-color 0.15s ease,
+    color 0.15s ease;
+}
+
+.room-modal-backdrop .sleepover-student-option:hover:not(:disabled),
+.room-modal-backdrop .sleepover-student-option.selected {
+  border-color: #6d23ed;
+  background: rgba(109, 35, 237, 0.06);
+}
+
+.room-modal-backdrop .sleepover-student-option:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.room-modal-backdrop .sleepover-student-option.assigned:disabled {
+  border-style: dashed;
+  background: #f4f4f5;
+  color: #a1a1aa;
+  opacity: 1;
+}
+
+.room-modal-backdrop .sleepover-student-option.assigned .sleepover-student-meta {
+  color: #6d23ed;
+}
+
+.room-modal-backdrop .sleepover-student-main {
+  color: #0f0f10;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.room-modal-backdrop .sleepover-student-meta {
+  color: #747678;
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.room-modal-backdrop .sleepover-empty-option {
+  padding: 16px;
+  border: 1px dashed #d8d2e7;
+  border-radius: 10px;
+  background: #ffffff;
+  color: #747678;
+  font-size: 13px;
+  font-weight: 600;
+  text-align: center;
+}
+
+.room-modal-backdrop .sleepover-reason-input {
+  min-height: 92px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+  resize: vertical;
+  line-height: 1.5;
+}
+
+@media (max-width: 768px) {
+  .room-modal-backdrop .sleepover-modal .sleepover-student-option {
+    align-items: flex-start;
+    flex-direction: column;
   }
 }

--- a/src/styles/Schedule.css
+++ b/src/styles/Schedule.css
@@ -11,8 +11,7 @@
 }
 
 
-.calendar-container,
-.scheduler-panel {
+.schedule-page .calendar-container, .schedule-page .scheduler-panel {
   min-width: 0;
 }
 
@@ -20,66 +19,63 @@
   display: none;
 }
 
-.schedule-error {
+.schedule-page .schedule-error {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 16px;
   margin-bottom: 14px;
   padding: 14px 16px;
-  border: 1px solid #ffd4d4;
+  border: 1px solid #fecaca;
   border-radius: 12px;
-  background: #fff7f7;
-  color: #b42326;
+  background: #fef2f2;
+  color: #b91c1c;
 }
 
-.schedule-error div,
-.schedule-error span {
+.schedule-page .schedule-error div, .schedule-page .schedule-error span {
   display: block;
 }
 
-.schedule-error strong {
+.schedule-page .schedule-error strong {
   font-size: 14px;
 }
 
-.schedule-error span {
+.schedule-page .schedule-error span {
   margin-top: 3px;
-  color: #805456;
+  color: #991b1b;
   font-size: 12px;
 }
 
-.schedule-error button {
+.schedule-page .schedule-error button {
   min-height: 34px;
   padding: 0 12px;
-  border: 1px solid #efb6b7;
+  border: 1px solid #fecaca;
   border-radius: 8px;
   background: #ffffff;
-  color: #b42326;
+  color: #b91c1c;
   font-size: 12px;
   font-weight: 800;
   cursor: pointer;
   white-space: nowrap;
 }
 
-.calendar,
-.scheduler-panel {
-  border: 1px solid #e6e6e7;
+.schedule-page .calendar, .schedule-page .scheduler-panel {
+  border: 1px solid #e5e5e5;
   background: #ffffff;
-  box-shadow: 0 4px 16px rgba(15, 15, 16, 0.04);
 }
 
-.month-selector {
+.schedule-page .month-selector {
   display: flex;
   align-items: center;
   gap: 10px;
   padding: 6px;
-  border: 1px solid #e6e6e7;
+  border: 1px solid #e5e5e5;
   border-radius: 10px;
   background: #fafafa;
   flex-shrink: 0;
 }
 
-.nav-button {
+.schedule-page .nav-button {
   width: 36px;
   height: 36px;
   padding: 0;
@@ -88,7 +84,7 @@
   border: 1px solid transparent;
   border-radius: 8px;
   background: #ffffff;
-  color: #5d5f60;
+  color: #52525b;
   font-size: 16px;
   font-weight: 800;
   line-height: 1;
@@ -99,70 +95,68 @@
     background 0.2s ease;
 }
 
-.nav-button:hover {
-  border-color: #6d23ed;
-  color: #6d23ed;
+.schedule-page .nav-button:hover {
+  background: #f4f4f5;
 }
 
-.month-text {
+.schedule-page .month-text {
   min-width: 108px;
   color: #0f0f10;
   font-size: 14px;
-  font-weight: 800;
+  font-weight: 700;
   text-align: center;
   white-space: nowrap;
 }
 
-.calendar-quick-select {
+.schedule-page .calendar-quick-select {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
   margin-bottom: 14px;
   padding: 12px 14px;
-  border: 1px solid #e6e6e7;
+  border: 1px solid #e5e5e5;
   border-radius: 12px;
   background: #ffffff;
-  box-shadow: 0 4px 16px rgba(15, 15, 16, 0.04);
 }
 
-.quick-select-copy {
+.schedule-page .quick-select-copy {
   min-width: 0;
   display: flex;
   align-items: baseline;
   gap: 8px;
 }
 
-.quick-select-label {
-  color: #6d23ed;
+.schedule-page .quick-select-label {
+  color: #747678;
   font-size: 12px;
-  font-weight: 700;
-  line-height: 1.2;
-  white-space: nowrap;
-}
-
-.quick-select-copy strong {
-  color: #5d5f60;
-  font-size: 13px;
   font-weight: 600;
   line-height: 1.2;
   white-space: nowrap;
 }
 
-.quick-select-actions {
+.schedule-page .quick-select-copy strong {
+  color: #0f0f10;
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.schedule-page .quick-select-actions {
   display: flex;
   justify-content: flex-end;
   gap: 8px;
   flex-wrap: wrap;
 }
 
-.quick-select-btn {
+.schedule-page .quick-select-btn {
   min-height: 34px;
   padding: 0 12px;
-  border: 1px solid #dfe0e2;
+  border: 1px solid #e4e4e7;
   border-radius: 8px;
   background: #ffffff;
-  color: #5d5f60;
+  color: #52525b;
   font-size: 13px;
   font-weight: 600;
   cursor: pointer;
@@ -174,42 +168,22 @@
     opacity 0.2s ease;
 }
 
-.quick-select-btn:hover:not(:disabled) {
-  border-color: #6d23ed;
+.schedule-page .quick-select-btn:hover:not(:disabled) {
+  background: #f4f4f5;
+}
+
+.schedule-page .quick-select-btn.active {
+  border-color: rgba(109, 35, 237, 0.35);
+  background: #ede9fe;
   color: #6d23ed;
 }
 
-.quick-select-btn.sunday:hover:not(:disabled),
-.quick-select-btn.red-day:hover:not(:disabled) {
-  border-color: #ffb3b3;
-  background: rgba(224, 68, 70, 0.06);
-  color: #d83d40;
-}
-
-.quick-select-btn.active {
-  border-color: #6d23ed;
-  background: rgba(109, 35, 237, 0.08);
-  color: #6d23ed;
-}
-
-.quick-select-btn.sunday.active {
-  border-color: #ffb3b3;
-  background: rgba(255, 77, 79, 0.08);
-  color: #e04446;
-}
-
-.quick-select-btn.red-day.active {
-  border-color: #ffb3b3;
-  background: rgba(224, 68, 70, 0.08);
-  color: #d83d40;
-}
-
-.quick-select-btn:disabled {
+.schedule-page .quick-select-btn:disabled {
   opacity: 0.55;
   cursor: not-allowed;
 }
 
-.calendar-legend {
+.schedule-page .calendar-legend {
   min-height: 38px;
   display: flex;
   align-items: center;
@@ -217,91 +191,90 @@
   gap: 12px;
   margin-bottom: 8px;
   padding: 0 4px;
-  color: #6f7073;
-  font-size: 11px;
-  font-weight: 800;
+  color: #747678;
+  font-size: 12px;
+  font-weight: 600;
 }
 
-.calendar-legend > span {
+.schedule-page .calendar-legend > span {
   display: inline-flex;
   align-items: center;
   gap: 5px;
   white-space: nowrap;
 }
 
-.legend-period svg {
+.schedule-page .legend-period svg {
   width: 14px;
   height: 14px;
 }
 
-.legend-period.morning {
-  color: #b87600;
+.schedule-page .legend-period.morning {
+  color: #b45309;
 }
 
-.legend-period.night {
-  color: #5744bd;
+.schedule-page .legend-period.night {
+  color: #5919c7;
 }
 
-.legend-divider {
+.schedule-page .legend-divider {
   width: 1px;
   height: 14px;
-  background: #d9dadd;
+  background: #e4e4e7;
 }
 
-.legend-gender::before {
+.schedule-page .legend-gender::before {
   width: 7px;
   height: 7px;
   border-radius: 999px;
   content: '';
 }
 
-.legend-gender.male::before {
-  background: #1492fc;
+.schedule-page .legend-gender.male::before {
+  background: #6d23ed;
 }
 
-.legend-gender.female::before {
+.schedule-page .legend-gender.female::before {
   background: #ed4ca4;
 }
 
-.calendar {
+.schedule-page .calendar {
   overflow: hidden;
   border-radius: 12px;
 }
 
-.calendar-weekdays,
-.calendar-grid {
+.schedule-page .calendar-weekdays, .schedule-page .calendar-grid {
   display: grid;
   grid-template-columns: repeat(7, minmax(0, 1fr));
 }
 
-.calendar-weekdays {
-  border-bottom: 1px solid #e6e6e7;
+.schedule-page .calendar-weekdays {
+  border-bottom: 1px solid #e5e5e5;
   background: #fafafa;
 }
 
-.weekday {
+.schedule-page .weekday {
   min-width: 0;
   padding: 11px 4px;
-  border-right: 1px solid #e6e6e7;
-  color: #5d5f60;
+  border-right: 1px solid #e5e5e5;
+  color: #52525b;
   font-size: 13px;
   font-weight: 800;
   text-align: center;
 }
 
-.weekday:last-child {
+.schedule-page .weekday:last-child {
   border-right: 0;
 }
 
-.weekday.sunday {
-  color: #ff4d4f;
+.schedule-page .weekday.sunday {
+  color: #ef4444;
 }
 
-.weekday.saturday {
-  color: #1492fc;
+.schedule-page .weekday.saturday {
+  color: #52525b;
 }
 
-.calendar-cell {
+.schedule-page .calendar-cell {
   position: relative;
   min-width: 0;
   min-height: 134px;
@@ -309,8 +282,8 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
-  border-right: 1px solid #e6e6e7;
-  border-bottom: 1px solid #e6e6e7;
+  border-right: 1px solid #e5e5e5;
+  border-bottom: 1px solid #e5e5e5;
   background: #ffffff;
   cursor: pointer;
   transition:
@@ -318,33 +291,33 @@
     box-shadow 0.2s ease;
 }
 
-.calendar-cell:nth-child(7n) {
+.schedule-page .calendar-cell:nth-child(7n) {
   border-right: 0;
 }
 
-.calendar-cell.inactive {
-  background: #f7f7f8;
+.schedule-page .calendar-cell.inactive {
+  background: #f4f4f5;
   cursor: default;
 }
 
-.calendar-cell.weekend:not(.inactive) {
+.schedule-page .calendar-cell.weekend:not(.inactive) {
   background: #fffdfd;
 }
 
-.calendar-cell.red-day:not(.inactive) {
-  background: #fffafa;
+.schedule-page .calendar-cell.red-day:not(.inactive) {
+  background: #fef2f2;
 }
 
-.calendar-cell.selected {
-  background: rgba(109, 35, 237, 0.08);
-  box-shadow: inset 0 0 0 2px #6d23ed;
+.schedule-page .calendar-cell.selected {
+  background: #ede9fe;
+  box-shadow: inset 0 0 0 1px #6d23ed;
 }
 
-.calendar-cell.today:not(.selected) {
+.schedule-page .calendar-cell.today:not(.selected) {
   box-shadow: inset 0 0 0 1px rgba(109, 35, 237, 0.45);
 }
 
-.calendar-cell-top {
+.schedule-page .calendar-cell-top {
   min-width: 0;
   display: flex;
   align-items: flex-start;
@@ -352,53 +325,52 @@
   gap: 6px;
 }
 
-.date-number {
+.schedule-page .date-number {
   min-width: 24px;
   height: 24px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   border-radius: 7px;
-  color: #5d5f60;
+  color: #52525b;
   font-size: 15px;
   font-weight: 800;
   line-height: 1;
 }
 
-.calendar-cell:not(.selected):not(.today) .date-number {
+.schedule-page .calendar-cell:not(.selected):not(.today) .date-number {
   min-width: auto;
   height: 22px;
   padding: 0 2px;
   justify-content: flex-start;
 }
 
-.calendar-cell.inactive:not(.red-day):not(.saturday) .date-number {
-  color: #b8babe;
+.schedule-page .calendar-cell.inactive:not(.red-day):not(.saturday) .date-number {
+  color: #a1a1aa;
 }
 
-.calendar-cell.red-day:not(.selected):not(.today) .date-number {
-  color: #e04446;
+.schedule-page .calendar-cell.red-day:not(.selected):not(.today) .date-number {
+  color: #ef4444;
 }
 
-.calendar-cell.saturday:not(.selected):not(.today) .date-number {
-  color: #1492fc;
+.schedule-page .calendar-cell.saturday:not(.selected):not(.today) .date-number {
+  color: #52525b;
 }
 
-.calendar-cell.today .date-number.today-number,
-.calendar-cell.selected .date-number {
-  background: #6d23ed;
-  color: #ffffff;
+.schedule-page .calendar-cell.today .date-number.today-number, .schedule-page .calendar-cell.selected .date-number {
+  background: #ede9fe;
+  color: #6d23ed;
 }
 
-.holiday-label {
+.schedule-page .holiday-label {
   min-width: 0;
   max-width: 100%;
   display: inline-flex;
   align-self: flex-start;
   padding: 3px 6px;
   border-radius: 6px;
-  background: rgba(224, 68, 70, 0.08);
-  color: #d83d40;
+  background: rgba(239, 68, 68, 0.08);
+  color: #ef4444;
   font-size: 10px;
   font-weight: 700;
   line-height: 1.2;
@@ -407,85 +379,85 @@
   white-space: nowrap;
 }
 
-.schedule-dots {
+.schedule-page .schedule-dots {
   display: flex;
   gap: 4px;
   padding-top: 5px;
 }
 
-.schedule-dot {
+.schedule-page .schedule-dot {
   width: 7px;
   height: 7px;
   border-radius: 999px;
 }
 
-.schedule-dot.male {
-  background: #1492fc;
+.schedule-page .schedule-dot.male {
+  background: #6d23ed;
 }
 
-.schedule-dot.female {
+.schedule-page .schedule-dot.female {
   background: #ed4ca4;
 }
 
-.schedule-indicators {
+.schedule-page .schedule-indicators {
   min-width: 0;
   display: flex;
   flex-direction: column;
   gap: 5px;
 }
 
-.calendar-schedule-row {
+.schedule-page .calendar-schedule-row {
   min-width: 0;
   display: block;
   padding: 5px 7px;
   border-radius: 7px;
 }
 
-.calendar-schedule-row.male {
-  background: rgba(20, 146, 252, 0.09);
-  box-shadow: inset 2px 0 0 rgba(20, 146, 252, 0.66);
+.schedule-page .calendar-schedule-row.male {
+  background: rgba(109, 35, 237, 0.08);
+  box-shadow: inset 2px 0 0 rgba(109, 35, 237, 0.55);
 }
 
-.calendar-schedule-row.female {
+.schedule-page .calendar-schedule-row.female {
   background: rgba(237, 76, 164, 0.09);
   box-shadow: inset 2px 0 0 rgba(237, 76, 164, 0.58);
 }
 
-.calendar-period-times {
+.schedule-page .calendar-period-times {
   min-width: 0;
   display: flex;
   flex-direction: column;
   gap: 2px;
 }
 
-.calendar-period-time {
+.schedule-page .calendar-period-time {
   min-width: 0;
   display: flex;
   align-items: center;
   gap: 3px;
   overflow: hidden;
   font-size: 9px;
-  font-weight: 850;
+  font-weight: 700;
   line-height: 1.2;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.calendar-period-time.morning {
-  color: #956000;
+.schedule-page .calendar-period-time.morning {
+  color: #b45309;
 }
 
-.calendar-period-time.night {
-  color: #5140a9;
+.schedule-page .calendar-period-time.night {
+  color: #5919c7;
 }
 
-.calendar-period-icon {
+.schedule-page .calendar-period-icon {
   width: 10px;
   height: 10px;
   flex: 0 0 10px;
 }
 
-.schedule-tag {
+.schedule-page .schedule-tag {
   min-width: 0;
   display: inline-flex;
   align-items: center;
@@ -504,11 +476,11 @@
   font-variant-numeric: tabular-nums;
 }
 
-.schedule-tag span {
+.schedule-page .schedule-tag span {
   flex: 0 0 auto;
 }
 
-.schedule-tag-time {
+.schedule-page .schedule-tag-time {
   min-width: 0;
   overflow: hidden;
   overflow-wrap: normal;
@@ -517,19 +489,17 @@
   word-break: normal;
 }
 
-.schedule-tag.male,
-.schedule-tag.blue {
-  background: rgba(20, 146, 252, 0.11);
-  color: #0d73c9;
+.schedule-page .schedule-tag.male, .schedule-page .schedule-tag.blue {
+  background: rgba(109, 35, 237, 0.1);
+  color: #5919c7;
 }
 
-.schedule-tag.female,
-.schedule-tag.pink {
-  background: rgba(237, 76, 164, 0.11);
+.schedule-page .schedule-tag.female, .schedule-page .schedule-tag.pink {
+  background: rgba(237, 76, 164, 0.1);
   color: #c62f83;
 }
 
-.scheduler-panel {
+.schedule-page .scheduler-panel {
   position: static;
   display: flex;
   flex-direction: column;
@@ -538,39 +508,35 @@
   border-radius: 12px;
 }
 
-.panel-header {
+.schedule-page .panel-header {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
   gap: 12px;
   padding-bottom: 12px;
-  border-bottom: 1px solid #e6e6e7;
+  border-bottom: 1px solid #ececef;
 }
 
-.panel-header > div {
+.schedule-page .panel-header > div {
   min-width: 0;
 }
 
-.scheduler-title {
+.schedule-page .scheduler-title {
   margin: 5px 0 0;
   color: #0f0f10;
-  font-size: 20px;
-  font-weight: 800;
-  line-height: 1.25;
-  letter-spacing: 0;
+  font-size: 17px;
+  font-weight: 700;
+  line-height: 1.3;
+  letter-spacing: -0.3px;
 }
 
-.selection-tools,
-.weekday-selector,
-.quick-apply-panel,
-.gender-section,
-.no-selection {
-  border: 1px solid #e6e6e7;
+.schedule-page .selection-tools, .schedule-page .weekday-selector, .schedule-page .quick-apply-panel, .schedule-page .gender-section, .schedule-page .no-selection {
+  border: 1px solid #e5e5e5;
   border-radius: 10px;
   background: #fafafa;
 }
 
-.selection-tools {
+.schedule-page .selection-tools {
   display: grid;
   grid-template-columns: 1fr auto;
   gap: 10px;
@@ -578,63 +544,60 @@
   padding: 12px;
 }
 
-.selection-summary {
+.schedule-page .selection-summary {
   min-width: 0;
   display: flex;
   flex-direction: column;
   gap: 4px;
 }
 
-.selection-summary-label {
+.schedule-page .selection-summary-label {
   color: #747678;
   font-size: 12px;
   font-weight: 800;
 }
 
-.selection-summary-value {
+.schedule-page .selection-summary-value {
   color: #6d23ed;
   font-size: 18px;
   font-weight: 800;
   line-height: 1;
 }
 
-.selection-tool-btn,
-.weekday-quick-btn {
+.schedule-page .selection-tool-btn, .schedule-page .weekday-quick-btn {
   min-height: 36px;
-  border: 1px solid #dfe0e2;
+  border: 1px solid #e4e4e7;
   border-radius: 8px;
   background: #ffffff;
-  color: #5d5f60;
+  color: #52525b;
   font-size: 13px;
-  font-weight: 800;
+  font-weight: 600;
   cursor: pointer;
   transition:
-    border-color 0.2s ease,
-    color 0.2s ease,
-    background 0.2s ease;
+    border-color 0.15s ease,
+    color 0.15s ease,
+    background-color 0.15s ease;
 }
 
-.selection-tool-btn {
+.schedule-page .selection-tool-btn {
   padding: 0 12px;
 }
 
-.selection-tool-btn:hover:not(:disabled),
-.weekday-quick-btn:hover {
-  border-color: #6d23ed;
-  color: #6d23ed;
+.schedule-page .selection-tool-btn:hover:not(:disabled), .schedule-page .weekday-quick-btn:hover {
+  background: #f4f4f5;
 }
 
-.selection-tool-btn:disabled {
-  background: #f0f1f2;
-  color: #b0b2b4;
+.schedule-page .selection-tool-btn:disabled {
+  background: #f4f4f5;
+  color: #a1a1aa;
   cursor: not-allowed;
 }
 
-.weekday-selector {
+.schedule-page .weekday-selector {
   padding: 14px;
 }
 
-.panel-section-heading {
+.schedule-page .panel-section-heading {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
@@ -642,36 +605,34 @@
   margin-bottom: 10px;
 }
 
-.section-label {
+.schedule-page .section-label {
   margin: 0;
   color: #0f0f10;
   font-size: 14px;
   font-weight: 800;
 }
 
-.panel-section-heading span,
-.current-time,
-.hint {
+.schedule-page .panel-section-heading span, .schedule-page .current-time, .schedule-page .hint {
   color: #747678;
   font-size: 12px;
   font-weight: 700;
 }
 
-.weekday-buttons {
+.schedule-page .weekday-buttons {
   display: grid;
   grid-template-columns: repeat(7, minmax(0, 1fr));
   gap: 5px;
   margin-bottom: 10px;
 }
 
-.weekday-btn {
+.schedule-page .weekday-btn {
   min-width: 0;
   min-height: 36px;
   padding: 0;
-  border: 1px solid #dfe0e2;
+  border: 1px solid #e4e4e7;
   border-radius: 8px;
   background: #ffffff;
-  color: #5d5f60;
+  color: #52525b;
   font-size: 13px;
   font-weight: 800;
   cursor: pointer;
@@ -681,50 +642,48 @@
     color 0.2s ease;
 }
 
-.weekday-btn:hover {
-  border-color: #6d23ed;
+.schedule-page .weekday-btn:hover {
+  background: #f4f4f5;
 }
 
-.weekday-btn.active {
-  border-color: #6d23ed;
-  background: #6d23ed;
-  color: #ffffff;
+.schedule-page .weekday-btn.active {
+  border-color: rgba(109, 35, 237, 0.35);
+  background: #ede9fe;
+  color: #6d23ed;
 }
 
-.weekday-btn.sunday {
-  color: #ff4d4f;
+.schedule-page .weekday-btn.sunday {
+  color: #ef4444;
 }
 
-.weekday-btn.sunday.active {
-  border-color: #ff4d4f;
-  background: #ff4d4f;
-  color: #ffffff;
+.schedule-page .weekday-btn.sunday.active {
+  border-color: rgba(239, 68, 68, 0.35);
+  background: #fef2f2;
+  color: #ef4444;
 }
 
-.weekday-btn.saturday {
-  color: #1492fc;
+.schedule-page .weekday-btn.saturday {
+  color: #52525b;
 }
 
-.weekday-btn.saturday.active {
-  border-color: #1492fc;
-  background: #1492fc;
-  color: #ffffff;
+.schedule-page .weekday-btn.saturday.active {
+  border-color: rgba(82, 82, 91, 0.35);
+  background: #f4f4f5;
+  color: #52525b;
 }
 
-.weekday-quick-actions {
+.schedule-page .weekday-quick-actions {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 8px;
   margin-bottom: 8px;
 }
 
-.weekday-quick-btn {
+.schedule-page .weekday-quick-btn {
   padding: 0 10px;
 }
 
-.apply-weekday-btn,
-.clear-weekday-btn,
-.action-button {
+.schedule-page .apply-weekday-btn, .schedule-page .clear-weekday-btn, .schedule-page .action-button {
   min-height: 42px;
   border: 0;
   border-radius: 8px;
@@ -739,49 +698,42 @@
     box-shadow 0.2s ease;
 }
 
-.apply-weekday-btn,
-.clear-weekday-btn {
+.schedule-page .apply-weekday-btn, .schedule-page .clear-weekday-btn {
   width: 100%;
 }
 
-.apply-weekday-btn {
+.schedule-page .apply-weekday-btn {
   margin-top: 2px;
   background: #6d23ed;
   color: #ffffff;
 }
 
-.apply-weekday-btn:hover:not(:disabled),
-.action-button.create:hover:not(:disabled),
-.action-button.apply-both:hover:not(:disabled) {
+.schedule-page .apply-weekday-btn:hover:not(:disabled), .schedule-page .action-button.create:hover:not(:disabled), .schedule-page .action-button.apply-both:hover:not(:disabled) {
   background: #5919c7;
   color: #ffffff;
-  box-shadow: 0 6px 16px rgba(109, 35, 237, 0.16);
 }
 
-.apply-weekday-btn:focus-visible,
-.clear-weekday-btn:focus-visible,
-.action-button:focus-visible {
+.schedule-page .apply-weekday-btn:focus-visible, .schedule-page .clear-weekday-btn:focus-visible, .schedule-page .action-button:focus-visible {
   outline: 3px solid rgba(109, 35, 237, 0.28);
   outline-offset: 3px;
 }
 
-.apply-weekday-btn:disabled,
-.action-button:disabled {
+.schedule-page .apply-weekday-btn:disabled, .schedule-page .action-button:disabled {
   opacity: 0.55;
   cursor: not-allowed;
 }
 
-.clear-weekday-btn {
+.schedule-page .clear-weekday-btn {
   margin-top: 8px;
-  background: #eff0f1;
-  color: #5d5f60;
+  background: #f4f4f5;
+  color: #52525b;
 }
 
-.clear-weekday-btn:hover {
+.schedule-page .clear-weekday-btn:hover {
   background: #e4e5e7;
 }
 
-.quick-apply-panel {
+.schedule-page .quick-apply-panel {
   display: grid;
   grid-template-columns: 1fr;
   gap: 12px;
@@ -789,21 +741,21 @@
   background: #ffffff;
 }
 
-.quick-apply-panel p {
+.schedule-page .quick-apply-panel p {
   margin: 4px 0 0;
-  color: #5d5f60;
+  color: #52525b;
   font-size: 13px;
   font-weight: 700;
   line-height: 1.45;
 }
 
-.quick-apply-label {
+.schedule-page .quick-apply-label {
   color: #6d23ed;
   font-size: 12px;
   font-weight: 800;
 }
 
-.schedule-workbench {
+.schedule-page .schedule-workbench {
   display: flex;
   flex-direction: column;
   gap: 10px;
@@ -811,55 +763,56 @@
   margin: 0 auto;
   padding: 12px;
   border-radius: 12px;
-  background: #fbfbfc;
+  background: #fafafa;
 }
 
-.workbench-heading {
+.schedule-page .workbench-heading {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
   gap: 12px;
 }
 
-.workbench-heading p {
+.schedule-page .workbench-heading p {
   margin: 4px 0 0;
-  color: #5d5f60;
+  color: #52525b;
   font-size: 13px;
   font-weight: 700;
   line-height: 1.45;
 }
 
-.ghost-reset-btn {
+.schedule-page .ghost-reset-btn {
   min-height: 34px;
   padding: 0 12px;
-  border: 1px solid #dfe0e2;
+  border: none;
   border-radius: 8px;
-  background: #ffffff;
-  color: #5d5f60;
-  font-size: 12px;
-  font-weight: 800;
+  background: transparent;
+  color: #747678;
+  font-size: 13px;
+  font-weight: 600;
   cursor: pointer;
   white-space: nowrap;
+  transition: background-color 0.15s ease, color 0.15s ease;
 }
 
-.ghost-reset-btn:hover {
-  border-color: #6d23ed;
-  color: #6d23ed;
+.schedule-page .ghost-reset-btn:hover {
+  background: #f4f4f5;
+  color: #52525b;
 }
 
-.editor-period-tabs {
+.schedule-page .editor-period-tabs {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 4px;
   padding: 4px;
-  border: 1px solid #e3e3e5;
+  border: 1px solid #e4e4e7;
   border-radius: 9px;
   background: #ffffff;
   width: min(420px, 100%);
   align-self: center;
 }
 
-.editor-period-tabs button {
+.schedule-page .editor-period-tabs button {
   min-height: 34px;
   display: flex;
   align-items: center;
@@ -868,49 +821,49 @@
   border: 0;
   border-radius: 6px;
   background: transparent;
-  color: #68696c;
+  color: #52525b;
   font-size: 12px;
-  font-weight: 850;
+  font-weight: 700;
   cursor: pointer;
 }
 
-.editor-period-tabs button svg {
+.schedule-page .editor-period-tabs button svg {
   width: 15px;
   height: 15px;
 }
 
-.editor-period-tabs button.active.morning {
-  background: #fff0bd;
-  color: #9c6400;
+.schedule-page .editor-period-tabs button.active.morning {
+  background: #fef3c7;
+  color: #b45309;
 }
 
-.editor-period-tabs button.active.night {
-  background: #e9e5ff;
-  color: #513db7;
+.schedule-page .editor-period-tabs button.active.night {
+  background: #ede9fe;
+  color: #5919c7;
 }
 
-.compact-editor-list {
+.schedule-page .compact-editor-list {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 7px;
 }
 
-.compact-schedule-editor {
+.schedule-page .compact-schedule-editor {
   padding: 10px;
-  border: 1px solid #e6e6e7;
+  border: 1px solid #e5e5e5;
   border-radius: 9px;
   background: #ffffff;
 }
 
-.compact-schedule-editor.male {
-  box-shadow: inset 3px 0 0 #1492fc;
+.schedule-page .compact-schedule-editor.male {
+  box-shadow: inset 3px 0 0 #6d23ed;
 }
 
-.compact-schedule-editor.female {
+.schedule-page .compact-schedule-editor.female {
   box-shadow: inset 3px 0 0 #ed4ca4;
 }
 
-.compact-editor-heading {
+.schedule-page .compact-editor-heading {
   min-width: 0;
   display: flex;
   align-items: center;
@@ -919,7 +872,7 @@
   margin-bottom: 8px;
 }
 
-.compact-editor-heading small {
+.schedule-page .compact-editor-heading small {
   min-width: 0;
   overflow: hidden;
   color: #747678;
@@ -929,14 +882,14 @@
   white-space: nowrap;
 }
 
-.compact-editor-controls {
+.schedule-page .compact-editor-controls {
   display: grid;
   grid-template-columns: minmax(0, 1fr);
   align-items: end;
   gap: 6px;
 }
 
-.compact-time-range {
+.schedule-page .compact-time-range {
   min-width: 0;
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
@@ -944,92 +897,91 @@
   gap: 4px;
 }
 
-.compact-time-field {
+.schedule-page .compact-time-field {
   min-width: 0;
   display: flex;
   flex-direction: column;
   gap: 3px;
 }
 
-.compact-time-field > span {
-  color: #7b7c7f;
+.schedule-page .compact-time-field > span {
+  color: #747678;
   font-size: 9px;
   font-weight: 800;
 }
 
-.compact-time-field input {
+.schedule-page .compact-time-field input {
   width: 100%;
   min-width: 0;
   height: 34px;
   padding: 0 6px;
-  border: 1px solid #dfe0e2;
+  border: 1px solid #e4e4e7;
   border-radius: 7px;
   background: #fafafa;
-  color: #19191a;
+  color: #0f0f10;
   font-size: 12px;
-  font-weight: 850;
+  font-weight: 700;
   outline: none;
 }
 
-.compact-time-field input:focus {
+.schedule-page .compact-time-field input:focus {
   border-color: #6d23ed;
   background: #ffffff;
   box-shadow: 0 0 0 2px rgba(109, 35, 237, 0.09);
 }
 
-.compact-time-separator {
+.schedule-page .compact-time-separator {
   padding-bottom: 8px;
-  color: #8a8b8d;
+  color: #747678;
   font-size: 12px;
-  font-weight: 900;
+  font-weight: 700;
 }
 
-.compact-editor-actions {
+.schedule-page .compact-editor-actions {
   display: flex;
   justify-content: flex-end;
   gap: 4px;
 }
 
-.compact-editor-actions .row-apply-btn,
-.compact-editor-actions .row-delete-btn {
+.schedule-page .compact-editor-actions .row-apply-btn, .schedule-page .compact-editor-actions .row-delete-btn {
   min-width: 45px;
   min-height: 34px;
   padding: 0 8px;
   font-size: 11px;
 }
 
-.apply-all-dormitories-btn {
+.schedule-page .apply-all-dormitories-btn {
   min-height: 36px;
-  border: 1px solid #d9cdf5;
+  border: 1px solid rgba(109, 35, 237, 0.28);
   border-radius: 8px;
-  background: #f4efff;
-  color: #5b27b8;
+  background: #ede9fe;
+  color: #5919c7;
   font-size: 12px;
-  font-weight: 850;
+  font-weight: 700;
   cursor: pointer;
 }
 
-.apply-all-dormitories-btn:hover:not(:disabled) {
-  border-color: #bca8e8;
-  background: #eadfff;
+.schedule-page .apply-all-dormitories-btn:hover:not(:disabled) {
+  border-color: rgba(109, 35, 237, 0.4);
+  background: #ddd6fe;
 }
 
-.apply-all-dormitories-btn:disabled {
+.schedule-page .apply-all-dormitories-btn:disabled {
   opacity: 0.55;
   cursor: not-allowed;
 }
 
-.time-table {
+.schedule-page .time-table {
   display: flex;
   flex-direction: column;
   gap: 10px;
 }
 
-.time-table-head {
+.schedule-page .time-table-head {
   display: none;
 }
 
-.time-table-row {
+.schedule-page .time-table-row {
   display: grid;
   grid-template-columns: 1fr;
   grid-template-areas:
@@ -1037,28 +989,23 @@
     'range'
     'actions';
   gap: 10px;
-  padding: 14px 14px 14px 16px;
-  border: 0;
-  border-radius: 8px;
+  padding: 14px;
+  border: 1px solid #f4f4f5;
+  border-radius: 10px;
   background: #ffffff;
-  box-shadow: 0 1px 0 rgba(15, 15, 16, 0.06);
 }
 
-.time-table-row.male {
-  background: #ffffff;
-  box-shadow:
-    inset 3px 0 0 #1492fc,
-    0 1px 0 rgba(15, 15, 16, 0.06);
+.schedule-page .time-table-row.male {
+  border-color: #f4f4f5;
+  box-shadow: inset 3px 0 0 #6d23ed;
 }
 
-.time-table-row.female {
-  background: #ffffff;
-  box-shadow:
-    inset 3px 0 0 #ed4ca4,
-    0 1px 0 rgba(15, 15, 16, 0.06);
+.schedule-page .time-table-row.female {
+  border-color: #f4f4f5;
+  box-shadow: inset 3px 0 0 #ed4ca4;
 }
 
-.dormitory-cell {
+.schedule-page .dormitory-cell {
   grid-area: dormitory;
   min-width: 0;
   display: flex;
@@ -1067,7 +1014,7 @@
   gap: 10px;
 }
 
-.dormitory-cell small {
+.schedule-page .dormitory-cell small {
   max-width: 100%;
   color: #747678;
   font-size: 11px;
@@ -1077,36 +1024,36 @@
   white-space: nowrap;
 }
 
-.attendance-periods {
+.schedule-page .attendance-periods {
   grid-area: range;
   display: grid;
   gap: 10px;
 }
 
-.period-time-block {
+.schedule-page .period-time-block {
   padding: 12px;
-  border: 1px solid #e6e6e7;
+  border: 1px solid #e5e5e5;
   border-radius: 10px;
 }
 
-.period-time-block.morning {
-  border-color: #f6dfa4;
-  background: #fffaf0;
+.schedule-page .period-time-block.morning {
+  border-color: #fde68a;
+  background: #fffbeb;
 }
 
-.period-time-block.night {
-  border-color: #ddd7f4;
-  background: #f8f7ff;
+.schedule-page .period-time-block.night {
+  border-color: rgba(109, 35, 237, 0.22);
+  background: #faf9ff;
 }
 
-.period-time-heading {
+.schedule-page .period-time-heading {
   display: flex;
   align-items: center;
   gap: 8px;
   margin-bottom: 10px;
 }
 
-.period-time-heading > div {
+.schedule-page .period-time-heading > div {
   min-width: 0;
   display: flex;
   flex: 1;
@@ -1115,13 +1062,13 @@
   gap: 8px;
 }
 
-.period-time-heading strong {
-  color: #2c2c2e;
+.schedule-page .period-time-heading strong {
+  color: #0f0f10;
   font-size: 13px;
-  font-weight: 900;
+  font-weight: 700;
 }
 
-.period-time-heading small {
+.schedule-page .period-time-heading small {
   overflow: hidden;
   color: #747678;
   font-size: 10px;
@@ -1130,7 +1077,7 @@
   white-space: nowrap;
 }
 
-.period-icon-wrap {
+.schedule-page .period-icon-wrap {
   width: 28px;
   height: 28px;
   display: grid;
@@ -1139,22 +1086,22 @@
   border-radius: 8px;
 }
 
-.period-time-block.morning .period-icon-wrap {
+.schedule-page .period-time-block.morning .period-icon-wrap {
   background: #fff0bf;
-  color: #d48a00;
+  color: #b45309;
 }
 
-.period-time-block.night .period-icon-wrap {
-  background: #e9e5ff;
-  color: #5c4ac7;
+.schedule-page .period-time-block.night .period-icon-wrap {
+  background: #ede9fe;
+  color: #5919c7;
 }
 
-.period-icon {
+.schedule-page .period-icon {
   width: 17px;
   height: 17px;
 }
 
-.time-range-cell {
+.schedule-page .time-range-cell {
   grid-area: range;
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
@@ -1162,81 +1109,80 @@
   align-items: center;
 }
 
-.period-time-block .time-range-cell {
+.schedule-page .period-time-block .time-range-cell {
   grid-area: auto;
 }
 
-.time-range-mark {
+.schedule-page .time-range-mark {
   color: #747678;
   font-size: 18px;
-  font-weight: 900;
+  font-weight: 700;
 }
 
-.time-control {
+.schedule-page .time-control {
   min-width: 0;
   display: flex;
   flex-direction: column;
   gap: 6px;
 }
 
-.time-manual-input {
+.schedule-page .time-manual-input {
   width: 100%;
   min-height: 42px;
   padding: 0 10px;
   border: 0;
   border-radius: 8px;
-  background: #f7f7f8;
+  background: #f4f4f5;
   color: #0f0f10;
   font-size: 15px;
-  font-weight: 900;
+  font-weight: 700;
   text-align: center;
   white-space: nowrap;
   outline: none;
 }
 
-.time-manual-input:focus {
+.schedule-page .time-manual-input:focus {
   background: #ffffff;
   box-shadow: inset 0 0 0 2px #6d23ed;
 }
 
-.time-preset-row {
+.schedule-page .time-preset-row {
   display: flex;
   justify-content: flex-start;
   gap: 4px;
   flex-wrap: wrap;
 }
 
-.time-preset-btn {
+.schedule-page .time-preset-btn {
   min-height: 28px;
   padding: 0 8px;
   border: 0;
   border-radius: 6px;
-  background: #f0f1f2;
-  color: #4b4d50;
+  background: #f4f4f5;
+  color: #52525b;
   font-size: 11px;
   font-weight: 800;
   cursor: pointer;
 }
 
-.time-preset-btn:hover {
-  background: #e7dcff;
+.schedule-page .time-preset-btn:hover {
+  background: #ede9fe;
   color: #6d23ed;
 }
 
-.time-preset-btn.active {
+.schedule-page .time-preset-btn.active {
   background: #6d23ed;
   color: #ffffff;
 }
 
-.row-actions {
+.schedule-page .row-actions {
   grid-area: actions;
   display: grid;
   grid-template-columns: 1fr auto;
   gap: 8px;
 }
 
-.row-apply-btn,
-.row-delete-btn {
+.schedule-page .row-apply-btn, .schedule-page .row-delete-btn {
   min-height: 36px;
   padding: 0 12px;
   border-radius: 8px;
@@ -1245,82 +1191,81 @@
   cursor: pointer;
 }
 
-.row-apply-btn {
+.schedule-page .row-apply-btn {
   border: 0;
   background: #6d23ed;
   color: #ffffff;
 }
 
-.row-apply-btn:hover:not(:disabled) {
+.schedule-page .row-apply-btn:hover:not(:disabled) {
   background: #5919c7;
 }
 
-.row-delete-btn {
+.schedule-page .row-delete-btn {
   border: 0;
-  background: #fff1f1;
-  color: #d83d40;
+  background: #fef2f2;
+  color: #ef4444;
   min-width: 68px;
 }
 
-.row-delete-btn:hover:not(:disabled) {
-  background: #ffe3e3;
+.schedule-page .row-delete-btn:hover:not(:disabled) {
+  background: #fee2e2;
 }
 
-.row-apply-btn:disabled,
-.row-delete-btn:disabled {
+.schedule-page .row-apply-btn:disabled, .schedule-page .row-delete-btn:disabled {
   opacity: 0.55;
   cursor: not-allowed;
 }
 
 /* Legacy action styles kept for older states during hot reload. */
-.workbench-actions {
+.schedule-page .workbench-actions {
   display: none;
 }
 
-.danger-zone {
+.schedule-page .danger-zone {
   display: none;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
   padding: 10px 12px;
-  border: 1px solid #f3d0d1;
+  border: 1px solid #fecaca;
   border-radius: 10px;
-  background: #fffafa;
+  background: #fef2f2;
 }
 
-.danger-zone span {
-  color: #9b2f31;
+.schedule-page .danger-zone span {
+  color: #b91c1c;
   font-size: 12px;
   font-weight: 800;
 }
 
-.danger-zone div {
+.schedule-page .danger-zone div {
   display: flex;
   gap: 6px;
 }
 
-.danger-text-btn {
+.schedule-page .danger-text-btn {
   min-height: 32px;
   padding: 0 10px;
   border: 0;
   border-radius: 7px;
   background: transparent;
-  color: #d83d40;
+  color: #ef4444;
   font-size: 12px;
   font-weight: 800;
   cursor: pointer;
 }
 
-.danger-text-btn:hover:not(:disabled) {
-  background: #ffecec;
+.schedule-page .danger-text-btn:hover:not(:disabled) {
+  background: #fee2e2;
 }
 
-.danger-text-btn:disabled {
+.schedule-page .danger-text-btn:disabled {
   opacity: 0.55;
   cursor: not-allowed;
 }
 
-.gender-section {
+.schedule-page .gender-section {
   display: flex;
   flex-direction: column;
   gap: 12px;
@@ -1328,15 +1273,15 @@
   background: #ffffff;
 }
 
-.gender-section.male {
-  border-left: 4px solid #1492fc;
+.schedule-page .gender-section.male {
+  border-left: 4px solid #6d23ed;
 }
 
-.gender-section.female {
+.schedule-page .gender-section.female {
   border-left: 4px solid #ed4ca4;
 }
 
-.gender-header {
+.schedule-page .gender-header {
   min-width: 0;
   display: flex;
   align-items: center;
@@ -1344,7 +1289,7 @@
   gap: 10px;
 }
 
-.gender-badge {
+.schedule-page .gender-badge {
   display: inline-flex;
   align-items: center;
   min-height: 28px;
@@ -1355,17 +1300,17 @@
   white-space: nowrap;
 }
 
-.gender-badge.male {
-  background: rgba(20, 146, 252, 0.12);
-  color: #0d73c9;
+.schedule-page .gender-badge.male {
+  background: rgba(109, 35, 237, 0.1);
+  color: #5919c7;
 }
 
-.gender-badge.female {
-  background: rgba(237, 76, 164, 0.12);
+.schedule-page .gender-badge.female {
+  background: rgba(237, 76, 164, 0.1);
   color: #c62f83;
 }
 
-.current-time {
+.schedule-page .current-time {
   min-width: 0;
   overflow: hidden;
   text-align: right;
@@ -1373,26 +1318,26 @@
   white-space: nowrap;
 }
 
-.time-picker-row {
+.schedule-page .time-picker-row {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 10px;
 }
 
-.time-field {
+.schedule-page .time-field {
   min-width: 0;
   display: flex;
   flex-direction: column;
   gap: 6px;
 }
 
-.time-label {
+.schedule-page .time-label {
   color: #747678;
   font-size: 12px;
   font-weight: 800;
 }
 
-.time-input-group {
+.schedule-page .time-input-group {
   min-width: 0;
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
@@ -1400,12 +1345,12 @@
   gap: 4px;
 }
 
-.time-input {
+.schedule-page .time-input {
   width: 100%;
   min-width: 0;
   min-height: 42px;
   padding: 0 5px;
-  border: 1px solid #dfe0e2;
+  border: 1px solid #e4e4e7;
   border-radius: 8px;
   background: #ffffff;
   color: #0f0f10;
@@ -1418,93 +1363,90 @@
     box-shadow 0.2s ease;
 }
 
-.time-input:focus {
+.schedule-page .time-input:focus {
   border-color: #6d23ed;
   box-shadow: 0 0 0 3px rgba(109, 35, 237, 0.1);
 }
 
-.time-input::-webkit-outer-spin-button,
-.time-input::-webkit-inner-spin-button {
+.schedule-page .time-input::-webkit-outer-spin-button, .schedule-page .time-input::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
 
-.time-input[type='number'] {
+.schedule-page .time-input[type='number'] {
   -moz-appearance: textfield;
 }
 
-.time-separator {
+.schedule-page .time-separator {
   color: #747678;
   font-size: 15px;
   font-weight: 800;
 }
 
-.gender-actions {
+.schedule-page .gender-actions {
   display: grid;
   grid-template-columns: 1fr;
   gap: 8px;
 }
 
-.gender-actions .action-button:only-child {
+.schedule-page .gender-actions .action-button:only-child {
   grid-column: 1 / -1;
 }
 
-.action-button {
+.schedule-page .action-button {
   width: 100%;
   padding: 0 12px;
   color: #ffffff;
 }
 
-.action-button.create,
-.action-button.apply-both {
+.schedule-page .action-button.create, .schedule-page .action-button.apply-both {
   background: #6d23ed;
   color: #ffffff;
 }
 
-.action-button.apply-both {
+.schedule-page .action-button.apply-both {
   min-height: 48px;
 }
 
-.action-button.create-female {
+.schedule-page .action-button.create-female {
   background: #ed4ca4;
   color: #ffffff;
 }
 
-.action-button.create-female:hover:not(:disabled) {
+.schedule-page .action-button.create-female:hover:not(:disabled) {
   background: #d43d90;
   color: #ffffff;
-  box-shadow: 0 6px 16px rgba(237, 76, 164, 0.14);
 }
 
-.action-button.update {
-  background: #1492fc;
+.schedule-page .action-button.update {
+  background: #6d23ed;
   color: #ffffff;
 }
 
-.action-button.update:hover:not(:disabled) {
-  background: #0d73c9;
+.schedule-page .action-button.update:hover:not(:disabled) {
+  background: #5919c7;
   color: #ffffff;
 }
 
-.action-button.delete {
-  border: 1px solid #f0b8ba;
+.schedule-page .action-button.delete {
+  border: 1px solid #fecaca;
   background: #ffffff;
-  color: #d83d40;
+  color: #ef4444;
 }
 
-.action-button.delete:hover:not(:disabled) {
-  border-color: #e77e81;
-  background: #fff1f1;
-  color: #c92f32;
+.schedule-page .action-button.delete:hover:not(:disabled) {
+  border-color: #f87171;
+  background: #fef2f2;
+  color: #dc2626;
   box-shadow: none;
 }
 
-.action-button.small {
+.schedule-page .action-button.small {
   min-height: 38px;
   font-size: 13px;
 }
 
-.no-selection {
+.schedule-page .no-selection {
   min-height: 156px;
   padding: 22px;
   display: flex;
@@ -1515,7 +1457,7 @@
   text-align: center;
 }
 
-.no-selection p {
+.schedule-page .no-selection p {
   margin: 0;
   color: #0f0f10;
   font-size: 14px;
@@ -1524,9 +1466,9 @@
   word-break: keep-all;
 }
 
-.no-selection .hint {
+.schedule-page .no-selection .hint {
   max-width: 300px;
-  color: #5d5f60;
+  color: #52525b;
   font-size: 13px;
   font-weight: 500;
   line-height: 1.45;
@@ -1544,47 +1486,46 @@
   }
 }
 
-.skeleton-cell {
+.schedule-page .skeleton-cell {
   cursor: default;
 }
 
-.skeleton-cell:hover {
+.schedule-page .skeleton-cell:hover {
   background: #ffffff;
 }
 
-.skeleton-date,
-.skeleton-tag {
-  background: #e6e6e7;
+.schedule-page .skeleton-date, .schedule-page .skeleton-tag {
+  background: #e5e5e5;
   border-radius: 8px;
   animation: skeleton-pulse 1.5s ease-in-out infinite;
 }
 
-.skeleton-date {
+.schedule-page .skeleton-date {
   width: 28px;
   height: 28px;
   margin-left: auto;
 }
 
-.skeleton-tags {
+.schedule-page .skeleton-tags {
   width: 100%;
   display: flex;
   flex-direction: column;
   gap: 5px;
 }
 
-.skeleton-tag {
+.schedule-page .skeleton-tag {
   height: 24px;
 }
 
-.skeleton-tag:nth-child(1) {
+.schedule-page .skeleton-tag:nth-child(1) {
   animation-delay: 0.1s;
 }
 
-.skeleton-tag:nth-child(2) {
+.schedule-page .skeleton-tag:nth-child(2) {
   animation-delay: 0.2s;
 }
 
-.loading-modal-overlay {
+.schedule-page .loading-modal-overlay {
   position: fixed;
   inset: 0;
   z-index: 1000;
@@ -1592,25 +1533,26 @@
   align-items: center;
   justify-content: center;
   padding: 20px;
-  background: rgba(15, 15, 16, 0.48);
+  background: rgba(15, 15, 16, 0.42);
 }
 
-.loading-modal {
+.schedule-page .loading-modal {
   width: min(360px, 100%);
   padding: 28px;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 14px;
+  border: 1px solid #e5e5e5;
   border-radius: 16px;
   background: #ffffff;
-  box-shadow: 0 18px 48px rgba(15, 15, 16, 0.2);
+  box-shadow: 0 18px 54px rgba(15, 15, 16, 0.18);
 }
 
-.loading-modal-spinner {
+.schedule-page .loading-modal-spinner {
   width: 44px;
   height: 44px;
-  border: 4px solid #e6e6e7;
+  border: 4px solid #e5e5e5;
   border-top-color: #6d23ed;
   border-radius: 50%;
   animation: spin 0.8s linear infinite;
@@ -1622,33 +1564,35 @@
   }
 }
 
-.loading-modal-title {
+.schedule-page .loading-modal-title {
   margin: 0;
   color: #0f0f10;
-  font-size: 18px;
+  font-size: 17px;
   font-weight: 800;
+  letter-spacing: -0.3px;
 }
 
-.loading-modal-progress {
+.schedule-page .loading-modal-progress {
   width: 100%;
   height: 8px;
   overflow: hidden;
   border-radius: 999px;
-  background: #eff0f1;
+  background: #f4f4f5;
 }
 
-.loading-modal-progress-bar {
+.schedule-page .loading-modal-progress-bar {
   height: 100%;
   border-radius: inherit;
   background: #6d23ed;
   transition: width 0.2s ease;
 }
 
-.loading-modal-text {
+.schedule-page .loading-modal-text {
   margin: 0;
   color: #747678;
   font-size: 13px;
-  font-weight: 800;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
 }
 
 @media (max-width: 1200px) {
@@ -1657,7 +1601,7 @@
     padding: 28px 24px;
   }
 
-  .scheduler-panel {
+  .schedule-page .scheduler-panel {
     position: static;
   }
 }
@@ -1669,93 +1613,93 @@
     overflow-x: hidden;
   }
 
-  .month-selector {
+  .schedule-page .month-selector {
     width: 100%;
     justify-content: space-between;
   }
 
-  .calendar-quick-select {
+  .schedule-page .calendar-quick-select {
     align-items: stretch;
     flex-direction: column;
     padding: 12px;
   }
 
-  .quick-select-actions {
+  .schedule-page .quick-select-actions {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
     width: 100%;
   }
 
-  .quick-select-btn {
+  .schedule-page .quick-select-btn {
     width: 100%;
   }
 
-  .calendar-cell {
+  .schedule-page .calendar-cell {
     min-height: 112px;
     padding: 7px 5px;
     gap: 5px;
   }
 
-  .weekday {
+  .schedule-page .weekday {
     padding: 9px 2px;
     font-size: 12px;
   }
 
-  .date-number {
+  .schedule-page .date-number {
     min-width: 22px;
     height: 22px;
     border-radius: 7px;
     font-size: 13px;
   }
 
-  .calendar-cell:not(.selected):not(.today) .date-number {
+  .schedule-page .calendar-cell:not(.selected):not(.today) .date-number {
     min-width: auto;
     height: 20px;
     padding: 0 1px;
   }
 
-  .schedule-dots {
+  .schedule-page .schedule-dots {
     display: flex;
   }
 
-  .schedule-indicators {
+  .schedule-page .schedule-indicators {
     gap: 4px;
   }
 
-  .calendar-schedule-row {
+  .schedule-page .calendar-schedule-row {
     padding: 4px;
   }
 
-  .calendar-period-time {
+  .schedule-page .calendar-period-time {
     font-size: 8px;
   }
 
-  .holiday-label {
+  .schedule-page .holiday-label {
     max-width: 100%;
     padding: 2px 4px;
     font-size: 9px;
   }
 
-  .schedule-tag {
+  .schedule-page .schedule-tag {
     gap: 0;
     padding: 4px;
     font-size: 9px;
     text-align: center;
   }
 
-  .schedule-tag > span:first-child {
+  .schedule-page .schedule-tag > span:first-child {
     display: none;
   }
 
-  .schedule-tag-time {
+  .schedule-page .schedule-tag-time {
     display: block;
   }
 
-  .scheduler-panel {
+  .schedule-page .scheduler-panel {
     padding: 14px;
   }
 
-  .compact-editor-list {
+  .schedule-page .compact-editor-list {
     grid-template-columns: 1fr;
   }
 }
@@ -1765,130 +1709,119 @@
     padding: 16px 10px;
   }
 
-  .quick-select-copy {
+  .schedule-page .quick-select-copy {
     justify-content: space-between;
   }
 
-  .quick-select-actions {
+  .schedule-page .quick-select-actions {
     grid-template-columns: 1fr;
   }
 
-  .calendar-legend {
+  .schedule-page .calendar-legend {
     justify-content: flex-start;
     gap: 8px;
     overflow-x: auto;
   }
 
-  .calendar-cell {
+  .schedule-page .calendar-cell {
     min-height: 58px;
     padding: 5px 3px;
     gap: 3px;
   }
 
-  .calendar-cell-top {
+  .schedule-page .calendar-cell-top {
     align-items: center;
   }
 
-  .date-number {
+  .schedule-page .date-number {
     min-width: 20px;
     height: 20px;
     border-radius: 6px;
     font-size: 12px;
   }
 
-  .calendar-cell:not(.selected):not(.today) .date-number {
+  .schedule-page .calendar-cell:not(.selected):not(.today) .date-number {
     min-width: auto;
     height: 18px;
     padding: 0 1px;
   }
 
-  .schedule-indicators {
+  .schedule-page .schedule-indicators {
     display: none;
   }
 
-  .compact-editor-controls {
+  .schedule-page .compact-editor-controls {
     grid-template-columns: 1fr;
   }
 
-  .compact-editor-actions {
+  .schedule-page .compact-editor-actions {
     justify-content: flex-end;
   }
 
-  .holiday-label {
+  .schedule-page .holiday-label {
     max-width: 100%;
     padding: 2px 3px;
     font-size: 8px;
   }
 
-  .schedule-dots {
+  .schedule-page .schedule-dots {
     padding-top: 0;
     gap: 3px;
   }
 
-  .schedule-dot {
+  .schedule-page .schedule-dot {
     width: 6px;
     height: 6px;
   }
 
-  .selection-tools,
-  .quick-apply-panel,
-  .schedule-workbench,
-  .time-picker-row,
-  .gender-actions,
-  .weekday-quick-actions {
+  .schedule-page .selection-tools, .schedule-page .quick-apply-panel, .schedule-page .schedule-workbench, .schedule-page .time-picker-row, .schedule-page .gender-actions, .schedule-page .weekday-quick-actions {
     grid-template-columns: 1fr;
   }
 
-  .workbench-heading,
-  .danger-zone {
+  .schedule-page .workbench-heading, .schedule-page .danger-zone {
     flex-direction: column;
     align-items: stretch;
   }
 
-  .time-table-head {
+  .schedule-page .time-table-head {
     display: none;
   }
 
-  .time-table-row {
+  .schedule-page .time-table-row {
     grid-template-columns: 1fr;
     gap: 8px;
   }
 
-  .period-time-heading > div {
+  .schedule-page .period-time-heading > div {
     align-items: flex-start;
     flex-direction: column;
     gap: 2px;
   }
 
-  .danger-zone div {
+  .schedule-page .danger-zone div {
     display: grid;
     grid-template-columns: 1fr 1fr;
   }
 
-  .selection-tool-btn,
-  .weekday-quick-btn,
-  .apply-weekday-btn,
-  .clear-weekday-btn,
-  .action-button {
+  .schedule-page .selection-tool-btn, .schedule-page .weekday-quick-btn, .schedule-page .apply-weekday-btn, .schedule-page .clear-weekday-btn, .schedule-page .action-button {
     min-height: 44px;
   }
 
-  .panel-section-heading,
-  .gender-header {
+  .schedule-page .panel-section-heading, .schedule-page .gender-header {
     flex-direction: column;
     align-items: flex-start;
   }
 
-  .current-time {
+  .schedule-page .current-time {
     width: 100%;
     text-align: left;
   }
 
-  .weekday-buttons {
+  .schedule-page .weekday-buttons {
     gap: 4px;
   }
 
-  .weekday-btn {
+  .schedule-page .weekday-btn {
     min-height: 34px;
     border-radius: 7px;
     font-size: 12px;
@@ -1897,94 +1830,93 @@
 
 /* 월간 달력 + 선택 날짜 상세 패널 */
 .schedule-page {
+  max-width: 1260px;
+  margin: 0 auto;
   grid-template-columns: minmax(560px, 1.08fr) minmax(400px, 0.92fr);
-  gap: 16px;
-  padding: 24px 28px 32px;
+  gap: 32px 24px;
+  padding: 32px 40px;
 }
 
 .schedule-page.no-selection-mode .scheduler-panel {
   display: flex;
 }
 
-.schedule-error,
-.schedule-bulk-tools {
+.schedule-page .schedule-error, .schedule-page .schedule-bulk-tools {
   grid-column: 1 / -1;
 }
 
-.schedule-error {
+.schedule-page .schedule-error {
   margin: 0;
 }
 
-.schedule-bulk-tools {
+.schedule-page .schedule-bulk-tools {
   display: grid;
   gap: 8px;
 }
 
-.schedule-bulk-tools .calendar-quick-select {
+.schedule-page .schedule-bulk-tools .calendar-quick-select {
   margin: 0;
-  box-shadow: none;
 }
 
-.schedule-bulk-tools .calendar-quick-select {
-  padding: 10px 12px;
-  border-radius: 11px;
+.schedule-page .schedule-bulk-tools .calendar-quick-select {
+  padding: 12px 14px;
+  border-radius: 12px;
 }
 
-.calendar-container,
-.scheduler-panel {
+.schedule-page .calendar-container, .schedule-page .scheduler-panel {
   min-width: 0;
-  border: 1px solid #e6e6e8;
-  border-radius: 16px;
+  border: 1px solid #e5e5e5;
+  border-radius: 12px;
   background: #ffffff;
-  box-shadow: 0 8px 26px rgba(15, 15, 16, 0.055);
 }
 
-.calendar-container {
+.schedule-page .calendar-container {
   padding: 20px;
 }
 
-.calendar-panel-header {
+.schedule-page .calendar-panel-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 16px;
   margin-bottom: 14px;
   padding-bottom: 14px;
-  border-bottom: 1px solid #eeeeef;
+  border-bottom: 1px solid #ececef;
 }
 
-.calendar-panel-header > div:first-child > span {
+.schedule-page .calendar-panel-header > div:first-child > span {
   display: block;
-  color: #6d23ed;
-  font-size: 10px;
-  font-weight: 900;
+  color: #8e8e99;
+  font-size: 11px;
+  font-weight: 600;
   letter-spacing: 0.06em;
   text-transform: uppercase;
 }
 
-.calendar-panel-header h3 {
+.schedule-page .calendar-panel-header h3 {
   margin: 3px 0 0;
-  color: #171719;
-  font-size: 18px;
-  font-weight: 900;
+  color: #0f0f10;
+  font-size: 17px;
+  font-weight: 700;
+  letter-spacing: -0.3px;
 }
 
-.calendar-container .month-selector {
+.schedule-page .calendar-container .month-selector {
   padding: 4px;
-  background: #f8f8f9;
+  background: #fafafa;
 }
 
-.calendar-container .nav-button {
+.schedule-page .calendar-container .nav-button {
   width: 32px;
   height: 32px;
 }
 
-.calendar-container .month-text {
+.schedule-page .calendar-container .month-text {
   min-width: 102px;
   font-size: 13px;
 }
 
-.calendar-container .calendar {
+.schedule-page .calendar-container .calendar {
   overflow: visible;
   border: 0;
   border-radius: 0;
@@ -1992,63 +1924,73 @@
   box-shadow: none;
 }
 
-.calendar-container .calendar-weekdays,
-.calendar-container .calendar-grid {
+.schedule-page .calendar-container .calendar-weekdays, .schedule-page .calendar-container .calendar-grid {
   border: 0;
 }
 
-.calendar-container .calendar-weekdays {
+.schedule-page .calendar-container .calendar-weekdays {
   background: transparent;
 }
 
-.calendar-container .weekday {
+.schedule-page .calendar-container .weekday {
   padding: 9px 2px 12px;
   border: 0;
-  color: #4c4b4f;
+  color: #52525b;
   font-size: 12px;
-  font-weight: 850;
+  font-weight: 700;
 }
 
-.calendar-container .calendar-grid {
+.schedule-page .calendar-container .calendar-grid {
   gap: 4px;
 }
 
-.calendar-container .calendar-cell {
+.schedule-page .calendar-container .calendar-cell {
   min-height: 82px;
   padding: 7px 4px;
   align-items: center;
   justify-content: flex-start;
   gap: 4px;
   overflow: visible;
-  border: 0;
+  border: 1px solid #f4f4f5;
   border-radius: 12px;
   background: transparent;
   box-shadow: none;
-  color: #2b292d;
+  color: #0f0f10;
   font-family: inherit;
   cursor: pointer;
+  transition:
+    border-color 0.15s ease,
+    background-color 0.15s ease;
 }
 
-.calendar-container .calendar-cell:focus-visible {
+.schedule-page .calendar-container .calendar-cell:hover:not(.inactive):not(.selected) {
+  border-color: #e4e4e7;
+  background: #fafafa;
+}
+
+.schedule-page .calendar-container .calendar-cell.selected {
+  border-color: rgba(109, 35, 237, 0.35);
+  background: #ede9fe;
+  box-shadow: none;
+}
+
+.schedule-page .calendar-container .calendar-cell:focus-visible {
   outline: 2px solid rgba(109, 35, 237, 0.35);
   outline-offset: -2px;
 }
 
-.calendar-container .calendar-cell.inactive {
+.schedule-page .calendar-container .calendar-cell.inactive {
   opacity: 0.34;
   background: transparent;
   cursor: default;
 }
 
-.calendar-container .calendar-cell.weekend:not(.inactive),
-.calendar-container .calendar-cell.red-day:not(.inactive),
-.calendar-container .calendar-cell.today:not(.selected) {
+.schedule-page .calendar-container .calendar-cell.weekend:not(.inactive), .schedule-page .calendar-container .calendar-cell.red-day:not(.inactive), .schedule-page .calendar-container .calendar-cell.today:not(.selected) {
   background: transparent;
   box-shadow: none;
 }
 
-.calendar-container .date-number,
-.calendar-container .calendar-cell:not(.selected):not(.today) .date-number {
+.schedule-page .calendar-container .date-number, .schedule-page .calendar-container .calendar-cell:not(.selected):not(.today) .date-number {
   min-width: 34px;
   width: 34px;
   height: 34px;
@@ -2056,42 +1998,43 @@
   display: grid;
   place-items: center;
   border-radius: 50%;
-  color: #343237;
+  color: #0f0f10;
   font-size: 14px;
-  font-weight: 850;
+  font-weight: 700;
   align-self: flex-start;
 }
 
-.calendar-container .calendar-cell.red-day:not(.selected) .date-number {
-  color: #ee4e52;
+.schedule-page .calendar-container .calendar-cell.red-day:not(.selected) .date-number {
+  color: #ef4444;
 }
 
-.calendar-container .calendar-cell.saturday:not(.selected) .date-number {
-  color: #258ce7;
+.schedule-page .calendar-container .calendar-cell.saturday:not(.selected) .date-number {
+  color: #52525b;
 }
 
-.calendar-container .calendar-cell.today:not(.selected) .date-number {
-  border: 1px solid #8f68df;
+.schedule-page .calendar-container .calendar-cell.today:not(.selected) .date-number {
+  border: 1px solid #6d23ed;
   background: transparent;
   color: #6d23ed;
 }
 
-.calendar-container .calendar-cell.selected .date-number {
-  background: #6d23ed;
-  color: #ffffff;
-  box-shadow: 0 7px 18px rgba(109, 35, 237, 0.22);
+.schedule-page .calendar-container .calendar-cell.selected .date-number {
+  background: transparent;
+  color: #6d23ed;
+  font-weight: 700;
+  box-shadow: none;
 }
 
-.calendar-container .holiday-label {
+.schedule-page .calendar-container .holiday-label {
   max-width: calc(100% - 8px);
   min-height: 13px;
   align-self: center;
   padding: 1px 4px;
-  font-size: 8px;
+  font-size: 9px;
   line-height: 1.2;
 }
 
-.calendar-slot-dots {
+.schedule-page .calendar-slot-dots {
   min-height: 8px;
   display: flex;
   align-items: center;
@@ -2099,39 +2042,40 @@
   gap: 3px;
 }
 
-.calendar-slot-dot {
+.schedule-page .calendar-slot-dot {
   width: 6px;
   height: 6px;
   display: block;
   border-radius: 50%;
 }
 
-.calendar-slot-dot.male {
-  background: #1492fc;
+.schedule-page .calendar-slot-dot.male {
+  background: #6d23ed;
 }
 
-.calendar-slot-dot.female {
+.schedule-page .calendar-slot-dot.female {
   background: #ed4ca4;
 }
 
-.calendar-container .calendar-legend {
+.schedule-page .calendar-container .calendar-legend {
   min-height: 42px;
   justify-content: center;
   margin: 12px 0 0;
   padding-top: 12px;
-  border-top: 1px solid #eeeeef;
+  border-top: 1px solid #ececef;
 }
 
-.legend-selected-dot {
+.schedule-page .legend-selected-dot {
   width: 11px;
   height: 11px;
   display: inline-block;
   margin-left: 4px;
-  border-radius: 50%;
-  background: #6d23ed;
+  border-radius: 3px;
+  background: #ede9fe;
+  box-shadow: inset 0 0 0 1px #6d23ed;
 }
 
-.scheduler-panel {
+.schedule-page .scheduler-panel {
   position: sticky;
   top: 82px;
   min-height: 690px;
@@ -2139,115 +2083,115 @@
   padding: 20px;
 }
 
-.scheduler-panel .panel-header {
+.schedule-page .scheduler-panel .panel-header {
   align-items: center;
   padding-bottom: 16px;
 }
 
-.detail-title-group {
+.schedule-page .detail-title-group {
   min-width: 0;
   display: flex;
   align-items: center;
   gap: 11px;
 }
 
-.detail-calendar-icon {
+.schedule-page .detail-calendar-icon {
   width: 38px;
   height: 38px;
   display: grid;
   flex: 0 0 38px;
   place-items: center;
   border-radius: 10px;
-  background: #eee7ff;
+  background: #ede9fe;
   color: #6d23ed;
 }
 
-.detail-calendar-icon svg {
+.schedule-page .detail-calendar-icon svg {
   width: 19px;
   height: 19px;
 }
 
-.scheduler-panel .scheduler-title {
+.schedule-page .scheduler-panel .scheduler-title {
   margin: 0;
   overflow: hidden;
-  font-size: 18px;
+  font-size: 17px;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.detail-title-group p {
+.schedule-page .detail-title-group p {
   margin: 3px 0 0;
-  color: #7c797f;
-  font-size: 11px;
-  font-weight: 700;
+  color: #747678;
+  font-size: 12px;
+  font-weight: 600;
 }
 
-.scheduler-panel .selection-tool-btn {
+.schedule-page .scheduler-panel .selection-tool-btn {
   min-height: 34px;
   padding: 0 10px;
   background: #ffffff;
-  font-size: 11px;
+  font-size: 12px;
 }
 
-.selected-schedule-list {
+.schedule-page .selected-schedule-list {
   display: flex;
   flex-direction: column;
   gap: 9px;
 }
 
-.selected-schedule-card {
+.schedule-page .selected-schedule-card {
   padding: 13px;
-  border: 1px solid #e5e5e7;
+  border: 1px solid #e5e5e5;
   border-radius: 12px;
   background: #ffffff;
 }
 
-.selected-schedule-card.male {
-  border-color: rgba(20, 146, 252, 0.28);
-  background: linear-gradient(115deg, rgba(20, 146, 252, 0.055), transparent 48%), #ffffff;
+.schedule-page .selected-schedule-card.male {
+  border-color: rgba(109, 35, 237, 0.28);
+  background: linear-gradient(115deg, rgba(109, 35, 237, 0.05), transparent 48%), #ffffff;
 }
 
-.selected-schedule-card.female {
+.schedule-page .selected-schedule-card.female {
   border-color: rgba(237, 76, 164, 0.27);
   background: linear-gradient(115deg, rgba(237, 76, 164, 0.05), transparent 48%), #ffffff;
 }
 
-.selected-schedule-card-header {
+.schedule-page .selected-schedule-card-header {
   display: flex;
   align-items: center;
   gap: 7px;
   margin-bottom: 9px;
 }
 
-.schedule-configured-badge {
+.schedule-page .schedule-configured-badge {
   padding: 3px 7px;
   border-radius: 999px;
-  background: #f0ebfb;
+  background: #ede9fe;
   color: #6d23ed;
-  font-size: 9px;
-  font-weight: 900;
+  font-size: 10px;
+  font-weight: 700;
 }
 
-.selected-schedule-delete {
+.schedule-page .selected-schedule-delete {
   width: 30px;
   height: 30px;
   display: grid;
   margin-left: auto;
   padding: 0;
   place-items: center;
-  border: 1px solid #f4d3d4;
+  border: 1px solid #fecaca;
   border-radius: 8px;
-  background: #fffafa;
-  color: #e04446;
+  background: #fef2f2;
+  color: #ef4444;
   cursor: pointer;
 }
 
-.selected-schedule-delete svg {
+.schedule-page .selected-schedule-delete svg {
   width: 15px;
   height: 15px;
 }
 
-.selected-period-row {
+.schedule-page .selected-period-row {
   width: 100%;
   min-height: 45px;
   display: grid;
@@ -2258,16 +2202,16 @@
   border: 0;
   border-radius: 8px;
   background: transparent;
-  color: #38353b;
+  color: #0f0f10;
   text-align: left;
   cursor: pointer;
 }
 
-.selected-period-row:hover {
+.schedule-page .selected-period-row:hover {
   background: rgba(109, 35, 237, 0.055);
 }
 
-.selected-period-row > span:nth-child(2) {
+.schedule-page .selected-period-row > span:nth-child(2) {
   min-width: 0;
   display: flex;
   align-items: center;
@@ -2275,25 +2219,25 @@
   gap: 8px;
 }
 
-.selected-period-row strong {
-  font-size: 11px;
-  font-weight: 850;
+.schedule-page .selected-period-row strong {
+  font-size: 12px;
+  font-weight: 700;
 }
 
-.selected-period-row small {
-  color: #6f6c72;
-  font-size: 11px;
-  font-weight: 800;
+.schedule-page .selected-period-row small {
+  color: #52525b;
+  font-size: 12px;
+  font-weight: 600;
   font-variant-numeric: tabular-nums;
 }
 
-.selected-period-row > svg {
+.schedule-page .selected-period-row > svg {
   width: 14px;
   height: 14px;
-  color: #817d85;
+  color: #747678;
 }
 
-.selected-period-icon {
+.schedule-page .selected-period-icon {
   width: 28px;
   height: 28px;
   display: grid;
@@ -2301,156 +2245,166 @@
   border-radius: 8px;
 }
 
-.selected-period-icon svg {
+.schedule-page .selected-period-icon svg {
   width: 15px;
   height: 15px;
 }
 
-.selected-period-row.morning .selected-period-icon {
-  background: #fff1bf;
-  color: #b97800;
+.schedule-page .selected-period-row.morning .selected-period-icon {
+  background: #fef3c7;
+  color: #b45309;
 }
 
-.selected-period-row.night .selected-period-icon {
-  background: #eae5ff;
-  color: #5744bd;
+.schedule-page .selected-period-row.night .selected-period-icon {
+  background: #ede9fe;
+  color: #5919c7;
 }
 
-.selected-schedule-empty {
+.schedule-page .selected-schedule-empty {
   width: 100%;
   min-height: 50px;
   display: flex;
   align-items: center;
   justify-content: center;
   gap: 7px;
-  border: 1px dashed #d9d6dc;
-  border-radius: 11px;
-  background: #fcfcfd;
-  color: #6f6b72;
-  font-size: 11px;
-  font-weight: 850;
+  border: 1px dashed #e4e4e7;
+  border-radius: 10px;
+  background: #fafafa;
+  color: #747678;
+  font-size: 12px;
+  font-weight: 600;
   cursor: pointer;
+  transition: border-color 0.15s ease, background-color 0.15s ease, color 0.15s ease;
 }
 
-.selected-schedule-empty span {
+.schedule-page .selected-schedule-empty span {
   color: #6d23ed;
   font-size: 18px;
   font-weight: 500;
 }
 
-.selected-schedule-empty.male:hover {
-  border-color: rgba(20, 146, 252, 0.5);
-  background: rgba(20, 146, 252, 0.04);
-  color: #0d73c9;
+.schedule-page .selected-schedule-empty:hover {
+  border-color: #c9c9cc;
+  background: #f4f4f5;
 }
 
-.selected-schedule-empty.female:hover {
+.schedule-page .selected-schedule-empty.male:hover {
+  border-color: rgba(109, 35, 237, 0.4);
+  background: rgba(109, 35, 237, 0.04);
+  color: #5919c7;
+}
+
+.schedule-page .selected-schedule-empty.female:hover {
   border-color: rgba(237, 76, 164, 0.46);
   background: rgba(237, 76, 164, 0.04);
   color: #c62f83;
 }
 
-.bulk-selection-card {
+.schedule-page .bulk-selection-card {
   display: flex;
   align-items: center;
   gap: 11px;
-  padding: 13px;
-  border: 1px solid #ddd3f4;
-  border-radius: 11px;
-  background: #faf8ff;
+  padding: 13px 14px;
+  border: 1px solid rgba(109, 35, 237, 0.28);
+  border-radius: 10px;
+  background: #fafafa;
   color: #6d23ed;
 }
 
-.bulk-selection-card > svg {
-  width: 23px;
-  height: 23px;
+.schedule-page .bulk-selection-card > svg {
+  width: 22px;
+  height: 22px;
 }
 
-.bulk-selection-card div {
+.schedule-page .bulk-selection-card div {
   display: flex;
   flex-direction: column;
   gap: 2px;
 }
 
-.bulk-selection-card strong {
-  color: #3d3744;
-  font-size: 12px;
-}
-
-.bulk-selection-card span {
-  color: #77727e;
-  font-size: 10px;
+.schedule-page .bulk-selection-card strong {
+  color: #0f0f10;
+  font-size: 13px;
   font-weight: 700;
 }
 
-.scheduler-panel .schedule-workbench {
+.schedule-page .bulk-selection-card span {
+  color: #747678;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.schedule-page .scheduler-panel .schedule-workbench {
   width: 100%;
   margin: 0;
   padding: 13px;
-  border: 1px solid #eceaed;
+  border: 1px solid #ececef;
   border-radius: 12px;
-  background: #f9f9fa;
+  background: #fafafa;
 }
 
-.scheduler-panel .workbench-heading p {
-  font-size: 11px;
+.schedule-page .scheduler-panel .workbench-heading p {
+  font-size: 12px;
+  font-weight: 600;
 }
 
-.editor-gender-tabs,
-.scheduler-panel .editor-period-tabs {
+.schedule-page .editor-gender-tabs, .schedule-page .scheduler-panel .editor-period-tabs {
   width: 100%;
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 4px;
   padding: 4px;
-  border: 1px solid #e4e2e6;
+  border: 1px solid #e4e4e7;
   border-radius: 9px;
   background: #ffffff;
 }
 
-.editor-gender-tabs button {
-  min-height: 32px;
+.schedule-page .editor-gender-tabs button {
+  min-height: 34px;
   border: 0;
-  border-radius: 6px;
+  border-radius: 8px;
   background: transparent;
-  color: #77737a;
-  font-size: 11px;
-  font-weight: 850;
+  color: #52525b;
+  font-size: 12px;
+  font-weight: 600;
   cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease;
 }
 
-.editor-gender-tabs button.active.male {
-  background: rgba(20, 146, 252, 0.12);
-  color: #0d73c9;
+.schedule-page .editor-gender-tabs button:hover:not(.active) {
+  background: #f4f4f5;
 }
 
-.editor-gender-tabs button.active.female {
-  background: rgba(237, 76, 164, 0.12);
-  color: #c62f83;
+.schedule-page .editor-gender-tabs button.active.all,
+.schedule-page .editor-gender-tabs button.active.male,
+.schedule-page .editor-gender-tabs button.active.female {
+  background: #ede9fe;
+  color: #6d23ed;
+  font-weight: 700;
 }
 
-.scheduler-panel .compact-editor-list {
+.schedule-page .scheduler-panel .compact-editor-list {
   grid-template-columns: 1fr;
 }
 
-.scheduler-panel .compact-schedule-editor {
+.schedule-page .scheduler-panel .compact-schedule-editor {
   padding: 11px;
 }
 
-.scheduler-panel .compact-editor-controls {
+.schedule-page .scheduler-panel .compact-editor-controls {
   grid-template-columns: minmax(0, 1fr) auto;
   gap: 8px;
 }
 
-.scheduler-panel .compact-editor-actions {
+.schedule-page .scheduler-panel .compact-editor-actions {
   align-self: end;
 }
 
-.scheduler-panel .apply-all-dormitories-btn {
+.schedule-page .scheduler-panel .apply-all-dormitories-btn {
   min-height: 38px;
 }
 
-.no-selection {
+.schedule-page .no-selection {
   min-height: 270px;
   display: flex;
   flex-direction: column;
@@ -2458,60 +2412,60 @@
   justify-content: center;
   gap: 7px;
   padding: 30px;
-  border: 1px dashed #ddd9e2;
+  border: 1px dashed #e4e4e7;
   border-radius: 13px;
-  background: #fcfbfe;
+  background: #fafafa;
   text-align: center;
 }
 
-.no-selection-icon {
+.schedule-page .no-selection-icon {
   width: 48px;
   height: 48px;
   display: grid;
   margin-bottom: 4px;
   place-items: center;
   border-radius: 14px;
-  background: #eee7ff;
+  background: #ede9fe;
   color: #6d23ed;
 }
 
-.no-selection-icon svg {
+.schedule-page .no-selection-icon svg {
   width: 23px;
   height: 23px;
 }
 
-.no-selection strong {
-  color: #343137;
+.schedule-page .no-selection strong {
+  color: #0f0f10;
   font-size: 14px;
-  font-weight: 900;
+  font-weight: 700;
 }
 
-.no-selection p {
+.schedule-page .no-selection p {
   max-width: 300px;
   margin: 0;
-  color: #807c83;
-  font-size: 11px;
-  font-weight: 700;
+  color: #747678;
+  font-size: 12px;
+  font-weight: 600;
   line-height: 1.55;
 }
 
-.schedule-guide {
+.schedule-page .schedule-guide {
   margin-top: auto;
   padding: 13px 14px;
-  border-radius: 11px;
-  background: #f8f8fa;
-  color: #716d75;
+  border-radius: 10px;
+  background: #fafafa;
+  color: #747678;
 }
 
-.schedule-guide strong {
+.schedule-page .schedule-guide strong {
   display: block;
   margin-bottom: 6px;
-  color: #555159;
-  font-size: 11px;
-  font-weight: 900;
+  color: #3f3f46;
+  font-size: 12px;
+  font-weight: 700;
 }
 
-.schedule-guide ul {
+.schedule-page .schedule-guide ul {
   display: flex;
   flex-direction: column;
   gap: 4px;
@@ -2519,10 +2473,10 @@
   padding-left: 16px;
 }
 
-.schedule-guide li {
-  font-size: 10px;
-  font-weight: 650;
-  line-height: 1.45;
+.schedule-page .schedule-guide li {
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.5;
 }
 
 @media (max-width: 1200px) {
@@ -2531,12 +2485,11 @@
     padding: 24px;
   }
 
-  .schedule-error,
-  .schedule-bulk-tools {
+  .schedule-page .schedule-error, .schedule-page .schedule-bulk-tools {
     grid-column: 1;
   }
 
-  .scheduler-panel {
+  .schedule-page .scheduler-panel {
     position: static;
     min-height: 0;
   }
@@ -2547,59 +2500,58 @@
     padding: 18px 14px 24px;
   }
 
-  .calendar-container {
+  .schedule-page .calendar-container {
     padding: 14px;
   }
 
-  .calendar-panel-header {
+  .schedule-page .calendar-panel-header {
     align-items: stretch;
     flex-direction: column;
   }
 
-  .calendar-container .calendar-cell {
+  .schedule-page .calendar-container .calendar-cell {
     min-height: 70px;
   }
 
-  .calendar-container .date-number,
-  .calendar-container .calendar-cell:not(.selected):not(.today) .date-number {
+  .schedule-page .calendar-container .date-number, .schedule-page .calendar-container .calendar-cell:not(.selected):not(.today) .date-number {
     min-width: 30px;
     width: 30px;
     height: 30px;
     font-size: 12px;
   }
 
-  .calendar-container .holiday-label {
+  .schedule-page .calendar-container .holiday-label {
     display: none;
   }
 
-  .scheduler-panel .compact-editor-controls {
+  .schedule-page .scheduler-panel .compact-editor-controls {
     grid-template-columns: 1fr;
   }
 }
 
 @media (max-width: 520px) {
-  .calendar-container .calendar-cell {
+  .schedule-page .calendar-container .calendar-cell {
     min-height: 56px;
     border-radius: 8px;
   }
 
-  .calendar-slot-dots {
+  .schedule-page .calendar-slot-dots {
     max-width: 28px;
     flex-wrap: wrap;
     gap: 2px;
   }
 
-  .calendar-slot-dot {
+  .schedule-page .calendar-slot-dot {
     width: 5px;
     height: 5px;
   }
 
-  .calendar-container .calendar-legend {
+  .schedule-page .calendar-container .calendar-legend {
     justify-content: flex-start;
     overflow-x: auto;
   }
 
-  .selected-period-row > span:nth-child(2) {
+  .schedule-page .selected-period-row > span:nth-child(2) {
     align-items: flex-start;
     flex-direction: column;
     gap: 2px;
@@ -2607,49 +2559,44 @@
 }
 
 /* 아침·저녁 통합 일정 설정 */
-.complete-schedule-apply-btn:hover:not(:disabled) {
-  background: #5d1fd3;
+.schedule-page .complete-schedule-apply-btn:hover:not(:disabled) {
+  background: #5919c7;
 }
 
-.complete-schedule-apply-btn:disabled {
+.schedule-page .complete-schedule-apply-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
 }
 
-.editor-gender-tabs {
+.schedule-page .editor-gender-tabs {
   grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
-.editor-gender-tabs button.active.all {
-  background: #eee7ff;
-  color: #5f24c6;
+.schedule-page .gender-badge.all {
+  background: #ede9fe;
+  color: #6d23ed;
 }
 
-.gender-badge.all {
-  background: #eee7ff;
-  color: #5f24c6;
-}
-
-.combined-schedule-editor {
-  padding: 11px;
-  border: 1px solid #e5e3e8;
-  border-radius: 11px;
+.schedule-page .combined-schedule-editor {
+  padding: 12px;
+  border: 1px solid #e5e5e5;
+  border-radius: 10px;
   background: #ffffff;
 }
 
-.combined-schedule-editor.all {
+.schedule-page .combined-schedule-editor.all {
   box-shadow: inset 3px 0 0 #6d23ed;
 }
 
-.combined-schedule-editor.male {
-  box-shadow: inset 3px 0 0 #1492fc;
+.schedule-page .combined-schedule-editor.male {
+  box-shadow: inset 3px 0 0 #6d23ed;
 }
 
-.combined-schedule-editor.female {
+.schedule-page .combined-schedule-editor.female {
   box-shadow: inset 3px 0 0 #ed4ca4;
 }
 
-.combined-editor-heading {
+.schedule-page .combined-editor-heading {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -2657,73 +2604,73 @@
   margin-bottom: 9px;
 }
 
-.combined-editor-heading > span:last-child {
-  color: #77747b;
-  font-size: 9px;
-  font-weight: 750;
+.schedule-page .combined-editor-heading > span:last-child {
+  color: #747678;
+  font-size: 11px;
+  font-weight: 500;
   text-align: right;
 }
 
-.combined-period-list {
+.schedule-page .combined-period-list {
   display: flex;
   flex-direction: column;
   gap: 7px;
 }
 
-.combined-period-card {
+.schedule-page .combined-period-card {
   min-width: 0;
   display: grid;
   grid-template-columns: 128px minmax(0, 1fr);
   align-items: center;
   gap: 10px;
-  padding: 9px;
-  border: 1px solid #eceaed;
-  border-radius: 9px;
-  background: #fcfcfd;
+  padding: 9px 10px;
+  border: 1px solid #ececef;
+  border-radius: 10px;
+  background: #fafafa;
 }
 
-.combined-period-card.morning {
-  background: linear-gradient(100deg, rgba(255, 213, 71, 0.08), transparent 46%), #fcfcfd;
+.schedule-page .combined-period-card.morning {
+  background: linear-gradient(100deg, rgba(255, 213, 71, 0.08), transparent 46%), #fafafa;
 }
 
-.combined-period-card.night {
-  background: linear-gradient(100deg, rgba(109, 35, 237, 0.06), transparent 46%), #fcfcfd;
+.schedule-page .combined-period-card.night {
+  background: linear-gradient(100deg, rgba(109, 35, 237, 0.06), transparent 46%), #fafafa;
 }
 
-.combined-period-card.disabled {
+.schedule-page .combined-period-card.disabled {
   opacity: 0.58;
 }
 
-.combined-period-heading {
+.schedule-page .combined-period-heading {
   min-width: 0;
   display: flex;
   align-items: center;
   gap: 7px;
 }
 
-.combined-period-heading > div {
+.schedule-page .combined-period-heading > div {
   min-width: 0;
   display: flex;
   flex-direction: column;
   gap: 2px;
 }
 
-.combined-period-heading strong {
-  color: #3d3941;
-  font-size: 11px;
-  font-weight: 900;
+.schedule-page .combined-period-heading strong {
+  color: #0f0f10;
+  font-size: 12px;
+  font-weight: 700;
 }
 
-.combined-period-heading small {
+.schedule-page .combined-period-heading small {
   overflow: hidden;
-  color: #817d85;
-  font-size: 8px;
-  font-weight: 700;
+  color: #747678;
+  font-size: 10px;
+  font-weight: 600;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.combined-time-range {
+.schedule-page .combined-time-range {
   min-width: 0;
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
@@ -2731,34 +2678,35 @@
   gap: 5px;
 }
 
-.compact-time-field input:disabled {
-  background: #f0f0f2;
-  color: #99969c;
+.schedule-page .compact-time-field input:disabled {
+  background: #f4f4f5;
+  color: #a1a1aa;
   cursor: not-allowed;
 }
 
-.complete-schedule-apply-btn {
+.schedule-page .complete-schedule-apply-btn {
   min-height: 42px;
   border: 0;
-  border-radius: 9px;
+  border-radius: 10px;
   background: #6d23ed;
   color: #ffffff;
-  font-size: 12px;
-  font-weight: 900;
+  font-size: 13px;
+  font-weight: 700;
   cursor: pointer;
+  transition: background-color 0.15s ease;
 }
 
 @media (max-width: 520px) {
-  .combined-editor-heading {
+  .schedule-page .combined-editor-heading {
     align-items: flex-start;
     flex-direction: column;
   }
 
-  .combined-editor-heading > span:last-child {
+  .schedule-page .combined-editor-heading > span:last-child {
     text-align: left;
   }
 
-  .combined-period-card {
+  .schedule-page .combined-period-card {
     grid-template-columns: 1fr;
   }
 }
@@ -2769,64 +2717,63 @@
     padding: 14px 8px 20px;
   }
 
-  .calendar-container {
+  .schedule-page .calendar-container {
     padding: 10px;
   }
 
-  .calendar-panel-header {
+  .schedule-page .calendar-panel-header {
     gap: 10px;
     margin-bottom: 10px;
     padding-bottom: 10px;
   }
 
-  .calendar-container .calendar-grid {
+  .schedule-page .calendar-container .calendar-grid {
     gap: 2px;
   }
 
-  .calendar-container .weekday {
+  .schedule-page .calendar-container .weekday {
     padding: 7px 1px 8px;
     font-size: 10px;
   }
 
-  .calendar-container .calendar-cell {
+  .schedule-page .calendar-container .calendar-cell {
     min-height: 48px;
     padding: 4px 2px;
   }
 
-  .calendar-container .date-number,
-  .calendar-container .calendar-cell:not(.selected):not(.today) .date-number {
+  .schedule-page .calendar-container .date-number, .schedule-page .calendar-container .calendar-cell:not(.selected):not(.today) .date-number {
     min-width: 24px;
     width: 24px;
     height: 24px;
     font-size: 11px;
   }
 
-  .calendar-container .month-text {
+  .schedule-page .calendar-container .month-text {
     min-width: 86px;
     font-size: 12px;
   }
 
-  .scheduler-panel {
+  .schedule-page .scheduler-panel {
     gap: 12px;
     padding: 14px;
   }
 
-  .scheduler-panel .panel-header {
+  .schedule-page .scheduler-panel .panel-header {
     align-items: stretch;
     flex-direction: column;
     gap: 10px;
   }
 
-  .scheduler-panel .scheduler-title {
+  .schedule-page .scheduler-panel .scheduler-title {
     overflow: visible;
     white-space: normal;
   }
 
-  .scheduler-panel .selection-tool-btn {
+  .schedule-page .scheduler-panel .selection-tool-btn {
     width: 100%;
   }
 
-  .scheduler-panel .schedule-workbench {
+  .schedule-page .scheduler-panel .schedule-workbench {
     padding: 10px;
   }
 }

--- a/src/styles/Schedule.css
+++ b/src/styles/Schedule.css
@@ -1595,7 +1595,7 @@
   font-variant-numeric: tabular-nums;
 }
 
-@media (max-width: 1200px) {
+@media (max-width: 1284px) {
   .schedule-page {
     grid-template-columns: 1fr;
     padding: 28px 24px;
@@ -2479,7 +2479,7 @@
   line-height: 1.5;
 }
 
-@media (max-width: 1200px) {
+@media (max-width: 1284px) {
   .schedule-page {
     grid-template-columns: 1fr;
     padding: 24px;

--- a/src/styles/Sleepover.css
+++ b/src/styles/Sleepover.css
@@ -1,166 +1,128 @@
+/* =========================================================
+   Sleepover Page 스타일
+   - 외박 확인 / 심야자습 / 휴대폰 제출 페이지가 공유하는 버튼·배너·모달 요소
+   - 페이지 고유 클래스(.sleepover-page)와 .check-page 하위로 스코핑
+   ========================================================= */
+
+/* ===== 액션 버튼 ===== */
 .sleepover-page .sleepover-primary-button,
 .sleepover-page .sleepover-secondary-button {
-  min-height: 38px;
-  padding: 0 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 40px;
+  padding: 0 14px;
   border-radius: 8px;
-  font-size: 14px;
-  font-weight: 700;
+  font-size: 13px;
+  font-weight: 600;
+  white-space: nowrap;
   cursor: pointer;
   transition:
-    background-color 0.2s,
-    border-color 0.2s,
-    color 0.2s,
-    opacity 0.2s;
-  white-space: nowrap;
+    background-color 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease,
+    opacity 0.15s ease;
 }
 
 .sleepover-page .sleepover-primary-button {
-  border: none;
+  border: 1px solid #6d23ed;
   background: #6d23ed;
   color: #ffffff;
 }
 
 .sleepover-page .sleepover-primary-button:hover:not(:disabled) {
+  border-color: #5919c7;
   background: #5919c7;
 }
 
 .sleepover-page .sleepover-secondary-button {
-  border: 1px solid #6d23ed;
+  border: 1px solid #e4e4e7;
   background: #ffffff;
-  color: #6d23ed;
+  color: #52525b;
 }
 
 .sleepover-page .sleepover-secondary-button:hover:not(:disabled) {
-  background: rgba(109, 35, 237, 0.08);
+  border-color: #d4d4d8;
+  background: #f4f4f5;
+  color: #3f3f46;
 }
 
 .sleepover-page .sleepover-primary-button:disabled,
-.sleepover-page .sleepover-secondary-button:disabled,
-.sleepover-delete-button:disabled {
+.sleepover-page .sleepover-secondary-button:disabled {
   opacity: 0.55;
   cursor: not-allowed;
 }
 
-.sleepover-message {
-  margin-bottom: 16px;
+/* ===== 동기화 결과 / 에러 배너 ===== */
+.check-page .sleepover-message {
+  width: min(1180px, 100%);
+  margin-left: auto;
+  margin-right: auto;
+  margin-bottom: 24px;
   padding: 12px 16px;
-  border: 1px solid rgba(109, 35, 237, 0.2);
-  border-radius: 8px;
-  background: #f6f2ff;
+  border: 1px solid rgba(109, 35, 237, 0.25);
+  border-radius: 10px;
+  background: #ede9fe;
   color: #4a19a8;
-  font-size: 14px;
-  font-weight: 700;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.5;
 }
 
-.sleepover-message.error {
-  border-color: rgba(255, 66, 66, 0.22);
-  background: rgba(255, 66, 66, 0.08);
-  color: #e1322e;
+.check-page .sleepover-message.error {
+  border-color: rgba(239, 68, 68, 0.28);
+  background: rgba(239, 68, 68, 0.08);
+  color: #b91c1c;
 }
 
-.sleepover-reason-cell {
+/* ===== 외박자 목록 테이블 ===== */
+.sleepover-page .sleepover-reason-cell {
   max-width: 280px;
+  color: #52525b;
+  font-size: 13px;
   line-height: 1.5;
   word-break: keep-all;
 }
 
-.sleepover-empty-cell {
-  height: 180px;
-  color: #747678;
-  font-weight: 600;
-}
-
-.sleepover-delete-button {
-  border: 1px solid #ff4242;
-  background: transparent;
-  color: #ff4242;
-  padding: 4.5px 12px;
-  border-radius: 4px;
-  font-size: 15px;
-  cursor: pointer;
-  transition:
-    background-color 0.2s,
-    color 0.2s,
-    opacity 0.2s;
-}
-
-.sleepover-delete-button:hover:not(:disabled) {
-  background: #ff4242;
-  color: #ffffff;
-}
-
-.sleepover-modal {
-  width: min(620px, 100%);
-}
-
-.sleepover-student-list {
-  max-height: 260px;
-  overflow-y: auto;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 4px 2px;
-}
-
-.sleepover-student-option {
-  width: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 12px 14px;
-  border: 1px solid #e6e6e7;
-  border-radius: 8px;
+.sleepover-page .sleepover-empty-cell {
+  padding: 48px 16px;
   background: #ffffff;
-  color: #0f0f10;
-  cursor: pointer;
-  transition:
-    border-color 0.2s,
-    background-color 0.2s,
-    color 0.2s;
-}
-
-.sleepover-student-option:hover:not(:disabled),
-.sleepover-student-option.selected {
-  border-color: #6d23ed;
-  background: rgba(109, 35, 237, 0.06);
-}
-
-.sleepover-student-option:disabled {
-  opacity: 0.55;
-  cursor: not-allowed;
-}
-
-.sleepover-student-main {
-  font-size: 14px;
-  font-weight: 800;
-}
-
-.sleepover-student-meta {
   color: #747678;
   font-size: 13px;
-  font-weight: 700;
-  white-space: nowrap;
-}
-
-.sleepover-empty-option {
-  padding: 14px;
-  border: 1px dashed #d6d6d8;
-  border-radius: 8px;
-  color: #747678;
-  font-size: 14px;
   font-weight: 600;
   text-align: center;
 }
 
-.sleepover-reason-input {
-  min-height: 92px;
-  padding-top: 12px;
-  padding-bottom: 12px;
-  resize: vertical;
-  line-height: 1.5;
+.sleepover-page .sleepover-delete-button {
+  min-height: 30px;
+  padding: 5px 12px;
+  border: 1px solid rgba(239, 68, 68, 0.45);
+  border-radius: 8px;
+  background: #ffffff;
+  color: #ef4444;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease,
+    opacity 0.15s ease;
 }
 
+.sleepover-page .sleepover-delete-button:hover:not(:disabled) {
+  border-color: #ef4444;
+  background: #ef4444;
+  color: #ffffff;
+}
+
+.sleepover-page .sleepover-delete-button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+/* ===== 외박자 추가 모달 ===== */
+/* 반응형 */
 @media (max-width: 1200px) {
   .sleepover-page .sleepover-primary-button,
   .sleepover-page .sleepover-secondary-button {
@@ -169,12 +131,7 @@
 }
 
 @media (max-width: 768px) {
-  .sleepover-reason-cell {
+  .sleepover-page .sleepover-reason-cell {
     max-width: none;
-  }
-
-  .sleepover-student-option {
-    align-items: flex-start;
-    flex-direction: column;
   }
 }

--- a/src/styles/TeacherPatchNote.css
+++ b/src/styles/TeacherPatchNote.css
@@ -1,166 +1,171 @@
-/* Teacher 전용 패치노트 페이지 스타일 */
+/* Teacher 전용 패치노트 페이지 스타일
+   - 대시보드/사이드바/탑바 톤의 디자인 토큰 적용 (배경 #fafafa, 카드 보더 중심, 그림자 없음)
+   - 모든 선택자는 .teacher-patchnote-page 하위로 스코핑하여 다른 페이지와의 충돌 방지 */
 
 .teacher-patchnote-page {
   min-height: 100%;
-  background: #f8f9fa;
-}
-
-.teacher-patchnote-loading {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  min-height: 400px;
-  gap: 16px;
-  color: #6b7280;
-}
-
-.teacher-patchnote-loading .loading-spinner {
-  width: 40px;
-  height: 40px;
-  border: 3px solid #e5e7eb;
-  border-top-color: #6d23ed;
-  border-radius: 50%;
-  animation: spin 1s linear infinite;
-}
-
-/* 스켈레톤 로딩 */
-.skeleton {
-  background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%);
-  background-size: 200% 100%;
-  animation: skeleton-loading 1.5s infinite;
-  border-radius: 4px;
-}
-
-@keyframes skeleton-loading {
-  0% { background-position: 200% 0; }
-  100% { background-position: -200% 0; }
-}
-
-.article-content-skeleton {
-  padding: 32px;
-}
-
-.skeleton-line {
-  height: 16px;
-  margin-bottom: 12px;
-  border-radius: 4px;
-}
-
-.skeleton-line.title {
-  height: 24px;
-  width: 60%;
-  margin-bottom: 20px;
-}
-
-.skeleton-line.short {
-  width: 40%;
-}
-
-.skeleton-line.medium {
-  width: 70%;
-}
-
-.skeleton-line.long {
-  width: 90%;
-}
-
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-/* 헤더 */
-.teacher-patchnote-header {
-  background: linear-gradient(135deg, #6d23ed 0%, #9747ff 100%);
   padding: 32px 40px;
-  color: white;
+  background: #fafafa;
+}
+
+/* 페이지 헤더 */
+.teacher-patchnote-header {
+  width: min(1180px, 100%);
+  margin: 0 auto 32px;
 }
 
 .teacher-patchnote-header .header-info h1 {
-  font-size: 24px;
-  font-weight: 700;
-  margin: 0 0 8px 0;
+  margin: 0;
+  font-size: 26px;
+  font-weight: 800;
+  letter-spacing: -0.3px;
+  color: #0f0f10;
 }
 
 .teacher-patchnote-header .header-info p {
+  margin: 6px 0 0;
   font-size: 14px;
-  opacity: 0.9;
-  margin: 0;
+  font-weight: 500;
+  color: #747678;
 }
 
 /* 컨테이너 */
 .teacher-patchnote-container {
+  width: min(1180px, 100%);
+  margin: 0 auto;
+}
+
+/* 로딩 스켈레톤 (페이지 스코프 내에서만 적용) */
+.teacher-patchnote-page .skeleton {
+  background: linear-gradient(90deg, #f1f1f3 25%, #e9e9ec 50%, #f1f1f3 75%);
+  background-size: 200% 100%;
+  animation: tpn-skeleton-loading 1.5s infinite ease-in-out;
+  border-radius: 4px;
+}
+
+@keyframes tpn-skeleton-loading {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+.teacher-patchnote-page .article-content-skeleton {
   padding: 24px;
+}
+
+.teacher-patchnote-page .skeleton-line {
+  height: 14px;
+  margin-bottom: 12px;
+  border-radius: 4px;
+}
+
+.teacher-patchnote-page .skeleton-line.title {
+  height: 22px;
+  width: 60%;
+  margin-bottom: 20px;
+}
+
+.teacher-patchnote-page .skeleton-line.short {
+  width: 40%;
+}
+
+.teacher-patchnote-page .skeleton-line.medium {
+  width: 70%;
+}
+
+.teacher-patchnote-page .skeleton-line.long {
+  width: 90%;
 }
 
 /* 레이아웃 */
 .teacher-patchnote-layout {
   display: flex;
+  align-items: flex-start;
   gap: 24px;
-  max-width: 1400px;
-  margin: 0 auto;
 }
 
-/* 사이드바 */
+/* 버전 목록 사이드바 */
 .teacher-patchnote-sidebar {
   width: 280px;
   flex-shrink: 0;
-  background: white;
+  background: #ffffff;
+  border: 1px solid #e5e5e5;
   border-radius: 12px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
   overflow: hidden;
+  position: sticky;
+  top: 24px;
 }
 
 .teacher-patchnote-sidebar .sidebar-header {
-  padding: 20px;
-  border-bottom: 1px solid #e5e7eb;
+  padding: 14px 16px;
+  border-bottom: 1px solid #ececef;
   display: flex;
   justify-content: space-between;
   align-items: center;
 }
 
 .teacher-patchnote-sidebar .sidebar-header h2 {
-  font-size: 16px;
-  font-weight: 600;
   margin: 0;
-  color: #1f2937;
+  font-size: 17px;
+  font-weight: 700;
+  color: #0f0f10;
 }
 
 .teacher-patchnote-sidebar .version-count {
+  padding: 3px 9px;
+  background: #f4f4f5;
+  border-radius: 999px;
   font-size: 12px;
-  color: #6b7280;
-  background: #f3f4f6;
-  padding: 4px 8px;
-  border-radius: 12px;
+  font-weight: 600;
+  color: #747678;
 }
 
 .teacher-patchnote-sidebar .version-list {
-  max-height: calc(100vh - 300px);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-height: calc(100vh - 320px);
   overflow-y: auto;
+  padding: 8px;
 }
 
 .teacher-patchnote-sidebar .version-item {
   display: block;
   width: 100%;
-  padding: 14px 16px;
+  padding: 11px 12px;
   border: none;
-  background: none;
+  border-radius: 8px;
+  background: transparent;
   text-align: left;
   cursor: pointer;
-  border-bottom: 1px solid #f3f4f6;
-  transition: background 0.15s;
+  font-family: inherit;
   box-sizing: border-box;
+  transition: background-color 0.15s ease;
 }
 
 .teacher-patchnote-sidebar .version-item:hover {
-  background: #f9fafb;
+  background: #f4f4f5;
+}
+
+.teacher-patchnote-sidebar .version-item:focus-visible {
+  outline: 2px solid #6d23ed;
+  outline-offset: 2px;
 }
 
 .teacher-patchnote-sidebar .version-item.active {
-  background: #f3e8ff;
-  border-left: 3px solid #6d23ed;
+  background: #ede9fe;
+}
+
+.teacher-patchnote-sidebar .version-item.active .version-number,
+.teacher-patchnote-sidebar .version-item.active .version-item-title {
+  color: #6d23ed;
+}
+
+.teacher-patchnote-sidebar .version-item.active .version-item-date {
+  color: rgba(109, 35, 237, 0.7);
 }
 
 /* 스켈레톤 아이템 */
@@ -177,42 +182,46 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 6px;
+  gap: 8px;
 }
 
 .teacher-patchnote-sidebar .version-item-header-left {
   display: flex;
   align-items: center;
   gap: 6px;
+  min-width: 0;
 }
 
 .teacher-patchnote-sidebar .version-number {
-  font-size: 13px;
-  font-weight: 600;
+  font-size: 12px;
+  font-weight: 800;
   color: #6d23ed;
+  white-space: nowrap;
 }
 
 .teacher-patchnote-sidebar .category-dot {
   width: 8px;
   height: 8px;
+  flex-shrink: 0;
   border-radius: 50%;
 }
 
 .teacher-patchnote-sidebar .version-item-title {
+  margin: 6px 0 0;
   font-size: 13px;
-  font-weight: 500;
-  color: #374151;
-  margin: 8px 0 0 0;
+  font-weight: 600;
+  color: #3f3f46;
+  line-height: 1.45;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
-  line-height: 1.4;
 }
 
 .teacher-patchnote-sidebar .version-item-date {
-  font-size: 11px;
-  color: #9ca3af;
+  font-size: 12px;
+  font-weight: 600;
+  color: #747678;
   white-space: nowrap;
 }
 
@@ -223,127 +232,153 @@
 }
 
 .teacher-patchnote-article {
-  background: white;
+  background: #ffffff;
+  border: 1px solid #e5e5e5;
   border-radius: 12px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
   overflow: hidden;
 }
 
 .teacher-patchnote-article .article-header {
-  padding: 32px;
-  border-bottom: 1px solid #e5e7eb;
+  padding: 24px;
+  border-bottom: 1px solid #ececef;
 }
 
 .teacher-patchnote-article .article-meta {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
-  margin-bottom: 16px;
+  margin-bottom: 14px;
 }
 
-.teacher-patchnote-article .category-badge {
+/* 뱃지 공통 형태 (카테고리 색상은 인라인 토큰 유지) */
+.teacher-patchnote-article .category-badge,
+.teacher-patchnote-article .version-badge,
+.teacher-patchnote-article .visibility-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: 999px;
   font-size: 12px;
-  font-weight: 600;
-  padding: 4px 12px;
-  border-radius: 20px;
+  font-weight: 700;
+  line-height: 1.3;
+  white-space: nowrap;
 }
 
 .teacher-patchnote-article .version-badge {
-  font-size: 12px;
-  font-weight: 600;
-  color: #6d23ed;
-  background: #f3e8ff;
-  padding: 4px 12px;
-  border-radius: 20px;
-}
-
-.teacher-patchnote-article .visibility-badge {
-  font-size: 12px;
-  font-weight: 500;
-  padding: 4px 12px;
-  border-radius: 20px;
+  color: #52525b;
+  background: #f4f4f5;
 }
 
 .teacher-patchnote-article .visibility-badge.teacher {
-  color: #7c3aed;
+  color: #6d23ed;
   background: #ede9fe;
 }
 
 .teacher-patchnote-article .article-title {
-  font-size: 28px;
-  font-weight: 700;
-  color: #1f2937;
-  margin: 0 0 12px 0;
+  margin: 0 0 10px;
+  font-size: 24px;
+  font-weight: 800;
+  letter-spacing: -0.3px;
+  line-height: 1.35;
+  color: #0f0f10;
 }
 
 .teacher-patchnote-article .article-info {
   display: flex;
-  gap: 16px;
-  font-size: 14px;
-  color: #6b7280;
+  align-items: center;
+  gap: 12px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #747678;
 }
 
+.teacher-patchnote-article .article-author::before {
+  content: '·';
+  margin-right: 12px;
+}
+
+/* 마크다운 아티클 타이포그래피 */
 .teacher-patchnote-article .article-content {
-  padding: 32px;
+  padding: 24px;
   font-size: 15px;
-  line-height: 1.8;
-  color: #374151;
+  font-weight: 500;
+  line-height: 1.7;
+  color: #3f3f46;
+}
+
+.teacher-patchnote-article .article-content > :first-child {
+  margin-top: 0;
+}
+
+.teacher-patchnote-article .article-content > :last-child {
+  margin-bottom: 0;
 }
 
 .teacher-patchnote-article .article-content h1 {
+  margin: 28px 0 12px;
   font-size: 24px;
-  font-weight: 700;
-  color: #1f2937;
-  margin: 16px 0 12px;
-}
-
-.teacher-patchnote-article .article-content h1:first-child {
-  margin-top: 0;
+  font-weight: 800;
+  letter-spacing: -0.3px;
+  line-height: 1.35;
+  color: #0f0f10;
 }
 
 .teacher-patchnote-article .article-content h2 {
+  margin: 28px 0 12px;
   font-size: 20px;
-  font-weight: 600;
-  color: #1f2937;
-  margin: 14px 0 10px;
-}
-
-.teacher-patchnote-article .article-content h2:first-child {
-  margin-top: 0;
+  font-weight: 800;
+  letter-spacing: -0.3px;
+  line-height: 1.4;
+  color: #0f0f10;
 }
 
 .teacher-patchnote-article .article-content h3 {
+  margin: 20px 0 8px;
   font-size: 17px;
-  font-weight: 600;
-  color: #374151;
-  margin: 12px 0 8px;
+  font-weight: 700;
+  color: #0f0f10;
 }
 
-.teacher-patchnote-article .article-content h3:first-child {
-  margin-top: 0;
+.teacher-patchnote-article .article-content h4,
+.teacher-patchnote-article .article-content h5,
+.teacher-patchnote-article .article-content h6 {
+  margin: 16px 0 8px;
+  font-size: 15px;
+  font-weight: 700;
+  color: #3f3f46;
+}
+
+.teacher-patchnote-article .article-content p {
+  margin: 10px 0;
+}
+
+.teacher-patchnote-article .article-content ul,
+.teacher-patchnote-article .article-content ol {
+  margin: 10px 0;
+  padding-left: 22px;
 }
 
 .teacher-patchnote-article .article-content ul {
-  padding-left: 24px;
-  margin: 8px 0;
   list-style-type: disc;
 }
 
 .teacher-patchnote-article .article-content li {
-  margin: 2px 0;
-  line-height: 1.5;
+  margin: 4px 0;
+  line-height: 1.6;
 }
 
-.teacher-patchnote-article .article-content code {
-  background: #f3f4f6;
-  padding: 2px 6px;
-  border-radius: 4px;
-  font-family: 'Fira Code', monospace;
-  font-size: 13px;
+.teacher-patchnote-article .article-content li::marker {
+  color: #6d23ed;
+}
+
+.teacher-patchnote-article .article-content strong {
+  font-weight: 700;
+  color: #0f0f10;
 }
 
 .teacher-patchnote-article .article-content a {
   color: #6d23ed;
+  font-weight: 600;
   text-decoration: none;
 }
 
@@ -351,52 +386,149 @@
   text-decoration: underline;
 }
 
-.teacher-patchnote-article .article-content .patchnote-image {
-  max-width: 100%;
-  border-radius: 8px;
-  margin: 16px 0;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+.teacher-patchnote-article .article-content code {
+  padding: 2px 6px;
+  background: #f4f4f5;
+  border-radius: 6px;
+  font-family: 'SF Mono', 'Menlo', 'Monaco', 'Fira Code', monospace;
+  font-size: 13px;
+  color: #6d23ed;
 }
 
-/* Empty & No Selection */
+.teacher-patchnote-article .article-content pre {
+  margin: 12px 0;
+  padding: 12px 16px;
+  background: #f4f4f5;
+  border-radius: 8px;
+  overflow-x: auto;
+}
+
+.teacher-patchnote-article .article-content pre code {
+  padding: 0;
+  background: transparent;
+  border-radius: 0;
+  color: #3f3f46;
+}
+
+.teacher-patchnote-article .article-content blockquote {
+  margin: 12px 0;
+  padding: 2px 0 2px 14px;
+  border-left: 3px solid #e5e5e5;
+  color: #747678;
+}
+
+.teacher-patchnote-article .article-content hr {
+  margin: 20px 0;
+  border: none;
+  border-top: 1px solid #ececef;
+}
+
+.teacher-patchnote-article .article-content table {
+  width: 100%;
+  margin: 12px 0;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.teacher-patchnote-article .article-content th,
+.teacher-patchnote-article .article-content td {
+  padding: 8px 12px;
+  border: 1px solid #ececef;
+  text-align: left;
+}
+
+.teacher-patchnote-article .article-content th {
+  background: #fafafa;
+  color: #0f0f10;
+  font-weight: 700;
+}
+
+.teacher-patchnote-article .article-content .patchnote-image {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  margin: 16px 0;
+  border: 1px solid #ececef;
+  border-radius: 8px;
+}
+
+/* 빈 상태 & 미선택 상태 */
 .teacher-patchnote-container .empty-state,
 .teacher-patchnote-main .no-selection {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
   text-align: center;
-  padding: 80px 40px;
-  background: white;
-  border-radius: 12px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  padding: 64px 32px;
+  background: #ffffff;
+  border: 1px dashed #d8d2e7;
+  border-radius: 10px;
+}
+
+.teacher-patchnote-main .no-selection {
+  min-height: 360px;
 }
 
 .teacher-patchnote-container .empty-state .empty-icon {
-  font-size: 48px;
-  margin-bottom: 16px;
+  font-size: 36px;
+  margin-bottom: 12px;
 }
 
 .teacher-patchnote-container .empty-state h3 {
-  font-size: 18px;
-  font-weight: 600;
-  color: #1f2937;
-  margin: 0 0 8px;
+  margin: 0 0 6px;
+  font-size: 15px;
+  font-weight: 700;
+  color: #0f0f10;
 }
 
 .teacher-patchnote-container .empty-state p,
 .teacher-patchnote-main .no-selection p {
-  color: #6b7280;
   margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: #747678;
 }
 
 /* 반응형 */
 @media (max-width: 900px) {
+  .teacher-patchnote-page {
+    padding: 24px 20px;
+  }
+
+  .teacher-patchnote-header {
+    margin-bottom: 24px;
+  }
+
   .teacher-patchnote-layout {
     flex-direction: column;
   }
-  
+
   .teacher-patchnote-sidebar {
+    position: static;
     width: 100%;
   }
-  
+
   .teacher-patchnote-sidebar .version-list {
-    max-height: 200px;
+    max-height: 220px;
+  }
+}
+
+@media (max-width: 480px) {
+  .teacher-patchnote-page {
+    padding: 20px 14px;
+  }
+
+  .teacher-patchnote-header .header-info h1 {
+    font-size: 22px;
+  }
+
+  .teacher-patchnote-article .article-header,
+  .teacher-patchnote-article .article-content {
+    padding: 16px;
+  }
+
+  .teacher-patchnote-article .article-title {
+    font-size: 20px;
   }
 }

--- a/src/styles/TeacherPatchNote.css
+++ b/src/styles/TeacherPatchNote.css
@@ -96,7 +96,7 @@
   border-radius: 12px;
   overflow: hidden;
   position: sticky;
-  top: 24px;
+  top: calc(60px + 24px);
 }
 
 .teacher-patchnote-sidebar .sidebar-header {


### PR DESCRIPTION
## Closes #72
Closes #73
Closes #74
Closes #75
Closes #76
Closes #77
Closes #78
Closes #79
Closes #80

## 변경사항

- 9개 페이지(인원 확인·심야자습·휴대폰 제출·외박·공지사항·일정 관리·방 관리·휴대폰 제출함·패치노트)를 대시보드/사이드바/탑바 톤에 맞춰 디자인 변경 (#72~#80, 세부 PR: #82~#86)
- 공용 모달 스타일을 `.room-modal-backdrop` 단일 소스로 통합하고 전역 선택자를 페이지 스코프로 한정해 스타일 충돌 제거
- 리뷰 반영: 모달 배경 선택자 오류 수정, 공지 스켈레톤 최대폭 적용, 일정 캘린더 브레이크포인트 조정, 패치노트 sticky 오프셋 수정, `:has()` 제거
- 기존(#81) 내용: 사이드바 메뉴·날짜 선택 UI, 아침/저녁 보기 전환, 대시보드 출결 카드·애니메이션, 테마 전환, 인트로, 기본 프로필 이미지

## 스크린샷/동영상

(추후 첨부 예정)

## 참고 사항

- #82(방 관리/제출함), #84(공지사항), #86(패치노트)가 아직 feature/#71 병합 전입니다 — 머지되면 이 PR에 자동 포함됩니다
- `npm run lint`, `npm run build` 통과
