### PR TITLE
design: 심야자습 확인 화면을 인원 확인 디자인으로 표준화

### DIFF
--- a/src/pages/NightStudy.tsx
+++ b/src/pages/NightStudy.tsx
@@ -7,7 +7,7 @@ import { studentService } from '../services/student.service';
 import { matchesKoreanNameSearch } from '../utils/korean-search';
 import { SearchIcon } from '../components/Icons';
 import '../styles/Check.css';
-import '../styles/Sleepover.css';
+import '../styles/NightStudy.css';
 import type { AttendanceResponse } from '../types/api';
 import { useSelectedDate } from '../context/SelectedDateContext';
 
@@ -203,7 +203,7 @@ export default function NightStudy() {
   );
 
   return (
-    <div className="check-page sleepover-page">
+    <div className="check-page night-study-page">
       <div className="controls-section">
         <div className="controls-left">
           <div className="date-picker">
@@ -240,7 +240,7 @@ export default function NightStudy() {
           </div>
           <button
             type="button"
-            className="sleepover-secondary-button"
+            className="night-study-secondary-button"
             onClick={() => syncMutation.mutate()}
             disabled={syncMutation.isPending}
           >
@@ -285,7 +285,7 @@ export default function NightStudy() {
 
       {(syncMessage || syncMutation.isError) && (
         <div
-          className={`sleepover-message ${syncMutation.isError ? 'error' : ''}`}
+          className={`night-study-message ${syncMutation.isError ? 'error' : ''}`}
         >
           {syncMutation.isError
             ? '심야자습 동기화에 실패했습니다. 다시 시도해주세요.'
@@ -307,8 +307,8 @@ export default function NightStudy() {
           </thead>
           <tbody>
             {isLoading ? (
-              <tr className="sleepover-empty-row">
-                <td colSpan={6} className="sleepover-empty-cell">
+              <tr className="night-study-empty-row">
+                <td colSpan={6} className="night-study-empty-cell">
                   심야자습 현황을 불러오는 중입니다.
                 </td>
               </tr>
@@ -328,8 +328,8 @@ export default function NightStudy() {
                 </tr>
               ))
             ) : (
-              <tr className="sleepover-empty-row">
-                <td colSpan={6} className="sleepover-empty-cell">
+              <tr className="night-study-empty-row">
+                <td colSpan={6} className="night-study-empty-cell">
                   조건에 맞는 학생이 없습니다.
                 </td>
               </tr>

--- a/src/styles/NightStudy.css
+++ b/src/styles/NightStudy.css
@@ -73,6 +73,9 @@
 @media (max-width: 768px) {
   .check-page.night-study-page .student-table tbody tr.night-study-empty-row {
     padding: 0;
+    border: none;
+    border-radius: 0;
+    background: transparent;
   }
 
   .check-page.night-study-page .student-table tbody .night-study-empty-cell {

--- a/src/styles/NightStudy.css
+++ b/src/styles/NightStudy.css
@@ -1,0 +1,87 @@
+/* 심야자습 화면 전용 스타일: 공용 인원 확인 레이아웃의 액션·상태 영역만 확장한다. */
+.check-page.night-study-page .night-study-secondary-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 40px;
+  padding: 0 14px;
+  border: 1px solid #e4e4e7;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #52525b;
+  font-size: 13px;
+  font-weight: 600;
+  white-space: nowrap;
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease,
+    opacity 0.15s ease;
+}
+
+.check-page.night-study-page .night-study-secondary-button:hover:not(:disabled) {
+  border-color: #d4d4d8;
+  background: #f4f4f5;
+  color: #3f3f46;
+}
+
+.check-page.night-study-page .night-study-secondary-button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.check-page.night-study-page .night-study-message {
+  width: min(1180px, 100%);
+  margin: 0 auto 24px;
+  padding: 12px 16px;
+  border: 1px solid rgba(109, 35, 237, 0.25);
+  border-radius: 10px;
+  background: #ede9fe;
+  color: #4a19a8;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.5;
+}
+
+.check-page.night-study-page .night-study-message.error {
+  border-color: rgba(239, 68, 68, 0.28);
+  background: rgba(239, 68, 68, 0.08);
+  color: #b91c1c;
+}
+
+.check-page.night-study-page .student-table tbody .night-study-empty-cell {
+  padding: 48px 16px;
+  background: #ffffff;
+  color: #747678;
+  font-size: 13px;
+  font-weight: 600;
+  text-align: center;
+}
+
+/* Check.css의 일반 행 hover 규칙에서 빈 상태 행을 제외한다. */
+.check-page.night-study-page .student-table tbody tr.night-study-empty-row:hover td {
+  background: #ffffff;
+}
+
+@media (max-width: 1200px) {
+  .check-page.night-study-page .night-study-secondary-button {
+    flex: 1 1 160px;
+  }
+}
+
+@media (max-width: 768px) {
+  .check-page.night-study-page .student-table tbody tr.night-study-empty-row {
+    padding: 0;
+  }
+
+  .check-page.night-study-page .student-table tbody .night-study-empty-cell {
+    display: block;
+    padding: 48px 16px;
+    text-align: center;
+  }
+
+  .check-page.night-study-page .student-table tbody .night-study-empty-cell::before {
+    display: none;
+  }
+}


### PR DESCRIPTION
## 변경 범위
- 심야자습 화면에서 외박 공용 스타일 의존과 sleepover 클래스명을 제거했습니다.
- 심야자습 전용 버튼·동기화 메시지·빈 상태 스타일을 추가하고 인원 확인 공용 레이아웃과 반응형 테이블을 유지했습니다.
- 빈 상태 행이 공용 테이블 hover 규칙의 영향을 받지 않도록 페이지 범위에서 고정했습니다.

## 검증 결과
- `git diff --check` 통과
- `npm run build` 통과
- `npm run lint` 통과

Closes #92