### PR TITLE
design: 휴대폰 제출 확인 화면을 인원 확인 디자인으로 표준화

### DIFF
--- a/src/pages/PhoneSubmission.tsx
+++ b/src/pages/PhoneSubmission.tsx
@@ -5,7 +5,7 @@ import { studentService } from '../services/student.service';
 import { matchesKoreanNameSearch } from '../utils/korean-search';
 import { SearchIcon } from '../components/Icons';
 import '../styles/Check.css';
-import '../styles/Sleepover.css';
+import '../styles/PhoneSubmission.css';
 import type { DeviceSubmission, DeviceSubmissionStatus, Gender } from '../types/api';
 import { useSelectedDate } from '../context/SelectedDateContext';
 
@@ -233,7 +233,7 @@ export default function PhoneSubmission() {
   };
 
   return (
-    <div className="check-page sleepover-page">
+    <div className="check-page phone-submission-page">
       <div className="controls-section">
         <div className="controls-left">
           <div className="date-picker">
@@ -305,7 +305,7 @@ export default function PhoneSubmission() {
       </div>
 
       {updateMutation.isError && (
-        <div className="sleepover-message error">
+        <div className="phone-submission-message error">
           휴대폰 제출 상태 수정에 실패했습니다. 다시 시도해주세요.
         </div>
       )}
@@ -325,8 +325,8 @@ export default function PhoneSubmission() {
           </thead>
           <tbody>
             {isLoading ? (
-              <tr className="sleepover-empty-row">
-                <td colSpan={7} className="sleepover-empty-cell">
+              <tr className="phone-submission-empty-row">
+                <td colSpan={7} className="phone-submission-empty-cell">
                   휴대폰 제출 현황을 불러오는 중입니다.
                 </td>
               </tr>
@@ -366,8 +366,8 @@ export default function PhoneSubmission() {
                 </tr>
               ))
             ) : (
-              <tr className="sleepover-empty-row">
-                <td colSpan={7} className="sleepover-empty-cell">
+              <tr className="phone-submission-empty-row">
+                <td colSpan={7} className="phone-submission-empty-cell">
                   조건에 맞는 학생이 없습니다.
                 </td>
               </tr>

--- a/src/styles/PhoneSubmission.css
+++ b/src/styles/PhoneSubmission.css
@@ -1,0 +1,68 @@
+/* =========================================================
+   Phone Submission Page 스타일
+   - 휴대폰 제출 화면의 오류·빈 상태를 페이지 범위에만 적용
+   ========================================================= */
+
+/* ===== 상태 변경 오류 배너 ===== */
+.phone-submission-page .phone-submission-message {
+  width: min(1180px, 100%);
+  margin-right: auto;
+  margin-bottom: 24px;
+  margin-left: auto;
+  padding: 12px 16px;
+  border: 1px solid rgba(109, 35, 237, 0.25);
+  border-radius: 10px;
+  background: #ede9fe;
+  color: #4a19a8;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.5;
+}
+
+.phone-submission-page .phone-submission-message.error {
+  border-color: rgba(239, 68, 68, 0.28);
+  background: rgba(239, 68, 68, 0.08);
+  color: #b91c1c;
+}
+
+/* ===== 빈 목록 상태 ===== */
+.check-page.phone-submission-page
+  .student-table
+  tbody
+  tr.phone-submission-empty-row:hover
+  td {
+  background: #ffffff;
+}
+
+.phone-submission-page .phone-submission-empty-cell {
+  padding: 48px 16px;
+  background: #ffffff;
+  color: #747678;
+  font-size: 13px;
+  font-weight: 600;
+  text-align: center;
+}
+
+@media (max-width: 768px) {
+  .phone-submission-page .student-table tbody .phone-submission-empty-row {
+    padding: 0;
+  }
+
+  .phone-submission-page
+    .student-table
+    tbody
+    .phone-submission-empty-row
+    .phone-submission-empty-cell {
+    display: block;
+    padding: 48px 16px;
+    text-align: center;
+  }
+
+  .phone-submission-page
+    .student-table
+    tbody
+    .phone-submission-empty-row
+    .phone-submission-empty-cell::before {
+    display: none;
+  }
+}

--- a/src/styles/PhoneSubmission.css
+++ b/src/styles/PhoneSubmission.css
@@ -46,6 +46,9 @@
 @media (max-width: 768px) {
   .phone-submission-page .student-table tbody .phone-submission-empty-row {
     padding: 0;
+    border: none;
+    border-radius: 0;
+    background: transparent;
   }
 
   .phone-submission-page


### PR DESCRIPTION
## 변경 범위
- 휴대폰 제출 화면에서 외박 공용 스타일 의존을 제거했습니다.
- 오류 배너와 빈 목록 상태를 `phone-submission-*` 전용 클래스로 분리했습니다.
- 빈 목록 행은 공용 테이블 hover 규칙의 영향을 받지 않도록 고정했습니다.

## 검증 결과
- `git diff --check` 통과
- `npm run build` 통과
- `npm run lint` 통과

Closes #93