### PR TITLE
design: 자치위원 화면을 인원 확인 디자인으로 표준화

### DIFF
--- a/src/pages/Council.tsx
+++ b/src/pages/Council.tsx
@@ -6,7 +6,6 @@ import { SearchIcon } from '../components/Icons';
 import { studentService } from '../services/student.service';
 import { matchesKoreanNameSearch } from '../utils/korean-search';
 import '../styles/Check.css';
-import '../styles/Sleepover.css';
 import '../styles/Council.css';
 import type { StudentResponse } from '../types/api';
 
@@ -116,7 +115,7 @@ export default function Council() {
       </div>
 
       {hasRequestError && (
-        <div className="sleepover-message error">
+        <div className="council-message council-message-error">
           요청 처리에 실패했습니다. 다시 시도해주세요.
         </div>
       )}
@@ -134,7 +133,7 @@ export default function Council() {
           </thead>
           <tbody>
             {isLoading ? (
-              <tr>
+              <tr className="council-empty-row">
                 <td colSpan={5} className="council-empty-cell">
                   자치위원 목록을 불러오는 중입니다.
                 </td>
@@ -165,7 +164,7 @@ export default function Council() {
                 </tr>
               ))
             ) : (
-              <tr>
+              <tr className="council-empty-row">
                 <td colSpan={5} className="council-empty-cell">
                   {searchQuery ? '검색 결과가 없습니다.' : '자치위원이 없습니다.'}
                 </td>

--- a/src/styles/Council.css
+++ b/src/styles/Council.css
@@ -1,4 +1,7 @@
 .council-page .council-add-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   min-height: 38px;
   padding: 0 16px;
   border: none;
@@ -23,38 +26,85 @@
   cursor: not-allowed;
 }
 
-.council-revoke-button {
-  border: 1px solid #ff4242;
-  background: transparent;
-  color: #ff4242;
-  padding: 4.5px 12px;
-  border-radius: 4px;
-  font-size: 15px;
+.council-page .council-revoke-button {
+  min-height: 30px;
+  padding: 5px 12px;
+  border: 1px solid rgba(239, 68, 68, 0.45);
+  border-radius: 8px;
+  background: #ffffff;
+  color: #ef4444;
+  font-size: 13px;
+  font-weight: 600;
   cursor: pointer;
   transition:
     background-color 0.2s,
+    border-color 0.2s,
     color 0.2s,
     opacity 0.2s;
 }
 
-.council-revoke-button:hover:not(:disabled) {
-  background: #ff4242;
+.council-page .council-revoke-button:hover:not(:disabled) {
+  border-color: #ef4444;
+  background: #ef4444;
   color: #ffffff;
 }
 
-.council-revoke-button:disabled {
+.council-page .council-revoke-button:disabled {
   opacity: 0.55;
   cursor: not-allowed;
 }
 
-.council-empty-cell {
-  height: 180px;
-  color: #747678;
+.council-page .council-message {
+  width: min(1180px, 100%);
+  margin: 0 auto 24px;
+  padding: 12px 16px;
+  border: 1px solid rgba(109, 35, 237, 0.25);
+  border-radius: 10px;
+  background: #ede9fe;
+  color: #4a19a8;
+  font-size: 13px;
   font-weight: 600;
+  line-height: 1.5;
+}
+
+.council-page .council-message-error {
+  border-color: rgba(239, 68, 68, 0.28);
+  background: rgba(239, 68, 68, 0.08);
+  color: #b91c1c;
+}
+
+.council-page .student-table .council-empty-cell {
+  height: 180px;
+  padding: 48px 16px;
+  background: #ffffff;
+  color: #747678;
+  font-size: 13px;
+  font-weight: 600;
+  text-align: center;
+}
+
+.council-page .student-table tbody tr.council-empty-row:hover td {
+  background: #ffffff;
 }
 
 @media (max-width: 1200px) {
   .council-page .council-add-button {
     flex: 1 1 160px;
+  }
+}
+
+@media (max-width: 768px) {
+  .council-page .student-table tbody tr.council-empty-row {
+    padding: 0;
+  }
+
+  .council-page .student-table tbody .council-empty-cell {
+    display: block;
+    padding: 48px 16px;
+    text-align: center;
+  }
+
+  .council-page .student-table tbody .council-empty-cell::before {
+    display: none;
   }
 }

--- a/src/styles/Council.css
+++ b/src/styles/Council.css
@@ -96,6 +96,9 @@
 @media (max-width: 768px) {
   .council-page .student-table tbody tr.council-empty-row {
     padding: 0;
+    border: none;
+    border-radius: 0;
+    background: transparent;
   }
 
   .council-page .student-table tbody .council-empty-cell {


### PR DESCRIPTION
## 변경 범위
- 자치위원 페이지의 외박 공용 스타일 의존을 제거했습니다.
- 추가·해제 버튼, 요청 오류 메시지, 빈 상태 행을 자치위원 전용 클래스와 인원 확인 디자인 토큰으로 정리했습니다.
- 모바일 빈 상태 행에서 공용 테이블 hover와 카드 레이아웃이 섞이지 않도록 처리했습니다.

## 검증 결과
- git diff --check
- npm run build
- npm run lint

Closes #94