### PR TITLE
fix: main Azure 배포 동시 실행 방지

### DIFF
--- a/.github/workflows/azure-static-web-apps-gray-bush-002455910.yml
+++ b/.github/workflows/azure-static-web-apps-gray-bush-002455910.yml
@@ -13,6 +13,11 @@ permissions:
   contents: read
   pull-requests: write
 
+# Azure Static Web Apps가 동일 브랜치의 동시 배포를 취소하지 않도록 직렬화한다.
+concurrency:
+  group: azure-static-web-apps-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build_and_deploy_job:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')


### PR DESCRIPTION
## 변경 사항
- 동일 브랜치의 Azure Static Web Apps 배포를 직렬화했습니다.
- 진행 중인 배포는 취소하지 않도록 설정했습니다.

## 검증
- YAML 파싱
- npm run build
- npm run lint

Closes #98